### PR TITLE
cleanup: Convert vars to replacements

### DIFF
--- a/onload/deviceplugin/0000-buildconfig.yaml
+++ b/onload/deviceplugin/0000-buildconfig.yaml
@@ -26,7 +26,7 @@ spec:
     node-role.kubernetes.io/worker: ""
   runPolicy: "Serial"
   source:
-    dockerfile: $(DEVICE_PLUGIN_DOCKERFILE)
+    dockerfile: (placeholder)
 
   strategy:
     dockerStrategy:

--- a/onload/deviceplugin/bc-dockerfile-varref.yaml
+++ b/onload/deviceplugin/bc-dockerfile-varref.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
-varReference:
-- path: spec/source/dockerfile
-  kind: BuildConfig

--- a/onload/deviceplugin/kustomization.yaml
+++ b/onload/deviceplugin/kustomization.yaml
@@ -11,15 +11,14 @@ configMapGenerator:
   files:
   - dockerfile=Dockerfile
 
-vars:
-- name: DEVICE_PLUGIN_DOCKERFILE
-  objref:
+replacements:
+- source:
     kind: ConfigMap
     name: onload-device-plugin-dockerfile
-    apiVersion: v1
-  fieldref:
-    fieldpath:
-      data.dockerfile
-
-configurations:
-- bc-dockerfile-varref.yaml
+    fieldPath: data.dockerfile
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-device-plugin
+    fieldPaths:
+    - spec.source.dockerfile

--- a/onload/userbuild/bc-dockerfile-varref.yaml
+++ b/onload/userbuild/bc-dockerfile-varref.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
-varReference:
-- path: spec/source/dockerfile
-  kind: BuildConfig

--- a/onload/userbuild/buildconfig.yaml
+++ b/onload/userbuild/buildconfig.yaml
@@ -29,7 +29,7 @@ spec:
     - type: "ConfigChange"
     - type: "ImageChange"
   source:
-    dockerfile: $(ONLOAD_DOCKERFILE)
+    dockerfile: (placeholder)
   strategy:
     dockerStrategy:
       buildArgs:

--- a/onload/userbuild/kustomization.yaml
+++ b/onload/userbuild/kustomization.yaml
@@ -10,15 +10,14 @@ configMapGenerator:
   files:
   - dockerfile=Dockerfile
 
-vars:
-- name: ONLOAD_DOCKERFILE
-  objref:
+replacements:
+- source:
     kind: ConfigMap
     name: onload-user-dockerfile
-    apiVersion: v1
-  fieldref:
-    fieldpath:
-      data.dockerfile
-
-configurations:
-- bc-dockerfile-varref.yaml
+    fieldPath: data.dockerfile
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-user
+    fieldPaths:
+    - spec.source.dockerfile


### PR DESCRIPTION
Onload uses Kustomize's `vars` to embed Dockerfiles into BuildConfig for the device plugin and UL builds. However, `vars` were deprecated in Kustomize v5.0.0. This patch converts `vars` to `replacements`, as suggested in the Kustomize docs, to address the deprecation.

---

More info: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/vars/#convert-vars-to-replacements

Tested in a virtualised config:
```
$ oc apply -k onload/dev
...
$ oc version
Client Version: 4.12.12
Kustomize Version: v4.5.7
Server Version: 4.12.12
Kubernetes Version: v1.25.7+eab9cc9
```

Additionally, dry-run tested against an older https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.10.0/ with:
```
$ ./oc-4.10.0 kustomize onload/dev
```
It substitutes the placeholder with the genuine Dockerfile content.