### PR TITLE
ON-14858: create phc devs in privileged sfptpd pod

### DIFF
--- a/sfptpd/0000-sfptpd-build.yaml
+++ b/sfptpd/0000-sfptpd-build.yaml
@@ -40,11 +40,11 @@ spec:
       ADD https://github.com/Xilinx-CNS/sfptpd/archive/refs/heads/master.tar.gz sfptpd.tar.gz
 
       RUN mkdir libcap libmnl sfptpd
-      RUN sh -c 'rpm -i libcap-*.src.rpm' \
-       && sh -c 'tar xzf ~/rpmbuild/SOURCES/libcap-*.tar.gz --strip-components=1 -C libcap' \
+      RUN rpm -i libcap-*.src.rpm \
+       && tar xzf ~/rpmbuild/SOURCES/libcap-*.tar.gz --strip-components=1 -C libcap \
        && make -C libcap/libcap install
-      RUN sh -c 'rpm -i libmnl-*.src.rpm' \
-       && sh -c 'tar xjf ~/rpmbuild/SOURCES/libmnl-*.tar.bz2 --strip-components=1 -C libmnl' \
+      RUN rpm -i libmnl-*.src.rpm \
+       && tar xjf ~/rpmbuild/SOURCES/libmnl-*.tar.bz2 --strip-components=1 -C libmnl \
        && { cd libmnl && ./configure --prefix=/usr && make install; }
       RUN tar xzf sfptpd.tar.gz --strip-components=1 -C sfptpd \
        && make -C sfptpd patch_version
@@ -61,4 +61,4 @@ spec:
       RUN microdnf -y install libmnl
       COPY --from=build /staged /
       WORKDIR /var/lib/sfptpd
-      ENTRYPOINT sfptpd "$@"
+      ENTRYPOINT for i in {0..31}; do mknod -m 600 /dev/ptp$i c 249 $i; done; sfptpd "$@"

--- a/sfptpd/1000-sfptpd-daemonset.yaml
+++ b/sfptpd/1000-sfptpd-daemonset.yaml
@@ -54,7 +54,7 @@ data:
 
     [ptp1]
     ptp_domain 0
-
+    transport ipv6
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -81,21 +81,10 @@ spec:
         volumeMounts:
         - name: conf-sfptpd
           mountPath: "/in"
-        - name: dev-ptp0
-          mountPath: "/dev/ptp0"
         securityContext:
-          capabilities:
-            add:
-              - NET_BIND_SERVICE
-              - NET_ADMIN
-              - NET_RAW
-              - SYS_TIME
-        command: ["sfptpd"]
-        args: ["-v", "--no-daemon", "-f", "/in/sfptpd.conf", "-i", "sf0"]
+          privileged: true
+        args: ["--no-daemon", "-f", "/in/sfptpd.conf", "-i", "sf0"]
       volumes:
       - name: conf-sfptpd
         configMap:
           name: sfptpd-config
-      - name: dev-ptp0
-        hostPath:
-          path: /dev/ptp0


### PR DESCRIPTION
Give in and make the sfptpd pod 'privileged'.

This is because you can't pass in the underlying device with mounts, only via a device plugin, which could come later (perhaps a generic time sync device plugin that would let you containerise any time sync app of your choice). And we might as well create the devices within the container to simplify the yaml and add more device instances easily.

Remove `CAP_NET_BIND_SERVICE` because this is available by default anyway.

Switch example config to use IPv6 transport so no IP address configuration is required on the interfaces (will use link-local scope by default).

### Testing done

Successfully starts syncing. (Then frequent drop-outs, assumed to be NetworkManager removing the LL address of secondary interface in test environment - to be tamed later.)

```
2023-06-21 23:27:39.488933: info: ptp ptp1: new best master selected: 40a6:b7ff:fe91:5e97(unknown)/1
2023-06-21 23:27:39.489019: notice: ptp ptp1: ptp ptp1: now in state: PTP_SLAVE, best master: 40a6:b7ff:fe91:5e97(unknown)/1
2023-06-21 23:27:39.489164: info: selection: rank 1: ptp1 by rule state (2) <- BEST
2023-06-21 23:27:39.489181: info: selection: rank 2: crny0 <- WORST
2023-06-21 23:27:39.987999 [ptp1:gm->phc0(enp6s0f0)], offset: 0.000, freq-adj: 0.000, in-sync: 0, one-way-delay: 0.000, parent-id: 40a6:b7ff:fe91:5e97, gm-id: 40a6:b7ff:fe91:5e97
2023-06-21 23:27:39.988023 [servo0:phc0->system], offset: -788068.812, freq-adj: 806756.385, in-sync: 0
2023-06-21 23:27:40.449113: info: ptp ptp1: received first Sync from Master
2023-06-21 23:27:40.988097 [ptp1:gm->phc0(enp6s0f0)], offset: 0.000, freq-adj: 0.000, in-sync: 0, one-way-delay: 0.000, parent-id: 40a6:b7ff:fe91:5e97, gm-id: 40a6:b7ff:fe91:5e97
2023-06-21 23:27:40.988144 [servo0:phc0->system], offset: -22656.500, freq-adj: 512554.075, in-sync: 0
2023-06-21 23:27:41.425961: info: ptp ptp1: received first DelayResp from Master
2023-06-21 23:27:41.987984 [ptp1:gm->phc0(enp6s0f0)], offset: 296789.500, freq-adj: -59357.900, in-sync: 0, one-way-delay: 3436.500, parent-id: 40a6:b7ff:fe91:5e97, gm-id: 40a6:b7ff:fe91:5e97
2023-06-21 23:27:41.988012 [servo0:phc0->system], offset: 457087.312, freq-adj: 314117.302, in-sync: 0
```