### PR TITLE
ON-14983: Fix incorrect oc invocation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,6 @@ Kustomize will remove build config but not build products. Confirm the state of 
 ```
 $ oc get image | grep onload
 ```
-Remove any outstanding manually with `oc image delete`. (Not providing any automated invocation to prevent removal of the false-positive images.)
+Remove any outstanding manually with `oc delete image`. (Not providing any automated invocation to prevent removal of the false-positive images.)
 
 Copyright (c) 2023 Advanced Micro Devices, Inc.


### PR DESCRIPTION
`oc image delete` is not a valid oc command.

## Testing done

Old:
```
$ oc image delete sha256:f39a172edcf5d78a73e51d43ec81adc30fbcd066b6eaca8e3abbac0630cc93e2
error: unknown command "delete sha256:f39a172edcf5d78a73e51d43ec81adc30fbcd066b6eaca8e3abbac0630cc93e2"
See 'oc image -h' for help and examples
```
New
```
$ oc delete image sha256:f39a172edcf5d78a73e51d43ec81adc30fbcd066b6eaca8e3abbac0630cc93e2
image.image.openshift.io "sha256:f39a172edcf5d78a73e51d43ec81adc30fbcd066b6eaca8e3abbac0630cc93e2" deleted
```