### PR TITLE
ON-14982: Use a fixed tag for sfptpd

### DIFF
--- a/sfptpd/0000-sfptpd-build.yaml
+++ b/sfptpd/0000-sfptpd-build.yaml
@@ -27,17 +27,20 @@ spec:
   strategy:
     dockerStrategy:
       buildArgs:
+      - name: SFPTPD_VERSION
+        value: ab881b3650c642f4dc8142c9b5052da3e6046cdf
   output:
     to:
       kind: ImageStreamTag
-      name: sfptpd:latest
+      name: sfptpd:git-ab881b3
   source:
     dockerfile: |
       FROM registry.access.redhat.com/ubi9/ubi-minimal AS build
       WORKDIR src
       RUN microdnf -y install make gcc tar bzip2 redhat-rpm-config
       RUN microdnf -y --enablerepo=ubi-9-baseos-source download --source libmnl libcap
-      ADD https://github.com/Xilinx-CNS/sfptpd/archive/refs/heads/master.tar.gz sfptpd.tar.gz
+      ARG SFPTPD_VERSION=master
+      ADD https://github.com/Xilinx-CNS/sfptpd/archive/${SFPTPD_VERSION}.tar.gz sfptpd.tar.gz
 
       RUN mkdir libcap libmnl sfptpd
       RUN rpm -i libcap-*.src.rpm \

--- a/sfptpd/1000-sfptpd-daemonset.yaml
+++ b/sfptpd/1000-sfptpd-daemonset.yaml
@@ -75,7 +75,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
       containers:
-      - image: image-registry.openshift-image-registry.svc:5000/sfptpd/sfptpd:latest
+      - image: image-registry.openshift-image-registry.svc:5000/sfptpd/sfptpd:git-ab881b3
         name: sfptpd
         imagePullPolicy: Always
         volumeMounts:


### PR DESCRIPTION
We want to avoid using `latest` as the only tag for our images.

I am using the commit hash directly here as the most recent tag in [public sfptpd repo](https://github.com/Xilinx-CNS/sfptpd/tags) doesn't have some of the new features we use in the container (specifically `--nodaemon` command line)

## Testing done
tested alongside #3 
sfptpd builds and daemonset runs