### PR TITLE
ON-14977: Check return values for non-nil errors

### DIFF
--- a/onload/deviceplugin/main.go
+++ b/onload/deviceplugin/main.go
@@ -10,7 +10,10 @@ import (
 
 func main() {
 	flag.Parse()
-	flag.Lookup("logtostderr").Value.Set("true")
+	err := flag.Lookup("logtostderr").Value.Set("true")
+	if err != nil {
+		glog.Fatalf("Failed to initialise device plugin: %v", err)
+	}
 	glog.Info("Starting device plugin")
 	manager, err := NewNicManager()
 	if err != nil {

--- a/onload/deviceplugin/mounts.go
+++ b/onload/deviceplugin/mounts.go
@@ -101,7 +101,10 @@ func (manager *NicManager) initMounts() {
 	}
 
 	for _, path := range libraryMounts {
-		manager.addLibraryMounts(path)
+		err := manager.addLibraryMounts(path)
+		if err != nil {
+			glog.Warningf("Failed to add library mount for %s (%v)", path, err)
+		}
 	}
 
 	manager.envs["LD_PRELOAD"] = path.Join(destLibDir, lib64path, "libonload.so")

--- a/onload/deviceplugin/rpc.go
+++ b/onload/deviceplugin/rpc.go
@@ -75,7 +75,10 @@ func (rpc *RPCServer) Serve() {
 	grpcServer := grpc.NewServer([]grpc.ServerOption{}...)
 	pluginapi.RegisterDevicePluginServer(grpcServer, rpc)
 	glog.Infof("RPC server listening on %s", rpc.listenSockPath)
-	grpcServer.Serve(listenSock)
+	err = grpcServer.Serve(listenSock)
+	if err != nil {
+		glog.Fatalf("grpcServer.Serve failed (%v)", err)
+	}
 }
 
 func (rpc *RPCServer) isUp() bool {


### PR DESCRIPTION
Passes static analyses check from `golangci-lint`

### Before
```
$ golangci-lint run
main.go:13:38: Error return value of `.Set` is not checked (errcheck)
        flag.Lookup("logtostderr").Value.Set("true")
                                            ^
mounts.go:104:27: Error return value of `manager.addLibraryMounts` is not checked (errcheck)
                manager.addLibraryMounts(path)
                                        ^
rpc.go:78:18: Error return value of `grpcServer.Serve` is not checked (errcheck)
        grpcServer.Serve(listenSock)
```
### After
```
$ golangci-lint run
```
(no output)