### PR TITLE
cleanup: Make Onload KMM Module fail if driver is already loaded

### DIFF
--- a/onload/kmm/onload-module.yaml
+++ b/onload/kmm/onload-module.yaml
@@ -9,6 +9,8 @@ spec:
     container:
       modprobe:
         moduleName: onload
+        parameters:
+        - '--first-time'
       kernelMappings:
         - regexp: '^.*\.x86_64$'
           containerImage: image-registry.openshift-image-registry.svc:5000/openshift-kmm/onload-module:latest


### PR DESCRIPTION
Use the `--first-time` parameter to fail the modprobe invocation when inserting the Onload drivers. When Onload is already loaded, the loader pod's post-start hook fails, runs pre-stop hook that tries to unload the Onload driver, and retries later.

This patch should help discover and recover from an inconsistent state of the node.

Suggested-by: Peter Colledge <peter.colledge@amd.com>
Thanks: Thomas Crawley <thomas.crawley@xilinx.com>

---

Testing notes in OCP v4.12.

Testing has exploited the Module's behaviour of not retrying to unload drivers if `modprobe -r` (remove) fails. I have removed the Onload Module resource while the Onload driver was still used by `cns-sfnettest` applications and then created it again.

The module loader pod has entered a crash loop:
```console
$ oc describe pod dev-onload-module-mbv5q-5bzw2 -n openshift-kmm
...
Events:
  Type     Reason               Age                From               Message
  ----     ------               ----               ----               -------
  Normal   Scheduled            12m                default-scheduler  Successfully assigned openshift-kmm/dev-onload-module-mbv5q-5bzw2 to compute-1
  Normal   AddedInterface       12m                multus             Add eth0 [192.168.6.95/23] from openshift-sdn
  Normal   Pulled               12m                kubelet            Successfully pulled image "image-registry.openshift-image-registry.svc:5000/openshift-kmm/onload-module:latest" in 34.104951ms (34.114682ms including waiting)
  Normal   Pulled               11m                kubelet            Successfully pulled image "image-registry.openshift-image-registry.svc:5000/openshift-kmm/onload-module:latest" in 45.051094ms (45.060496ms including waiting)
  Normal   Pulling              10m (x3 over 12m)  kubelet            Pulling image "image-registry.openshift-image-registry.svc:5000/openshift-kmm/onload-module:latest"
  Normal   Created              10m (x3 over 12m)  kubelet            Created container module-loader
  Normal   Started              10m (x3 over 12m)  kubelet            Started container module-loader
  Normal   Pulled               10m                kubelet            Successfully pulled image "image-registry.openshift-image-registry.svc:5000/openshift-kmm/onload-module:latest" in 43.779466ms (43.785043ms including waiting)
  Warning  FailedPostStartHook  10m (x3 over 12m)  kubelet            Exec lifecycle hook ([/bin/sh -c modprobe -v -d /opt onload --first-time]) for Container "module-loader" in Pod "dev-onload-module-mbv5q-5bzw2_openshift-kmm(440ab480-ae9b-4462-868a-db4f721693f5)" failed - error: command '/bin/sh -c modprobe -v -d /opt onload --first-time' exited with 1: modprobe: ERROR: could not insert 'onload': Module already in kernel
, message: "modprobe: ERROR: could not insert 'onload': Module already in kernel\n"
  Normal   Killing            10m (x3 over 12m)  kubelet  FailedPostStartHook
  Warning  FailedPreStopHook  10m (x3 over 12m)  kubelet  Exec lifecycle hook ([/bin/sh -c modprobe -rv -d /opt onload]) for Container "module-loader" in Pod "dev-onload-module-mbv5q-5bzw2_openshift-kmm(440ab480-ae9b-4462-868a-db4f721693f5)" failed - error: command '/bin/sh -c modprobe -rv -d /opt onload' exited with 1: modprobe: FATAL: Module onload is in use.
, message: "modprobe: FATAL: Module onload is in use.\n"
  Warning  BackOff  10m (x4 over 11m)  kubelet  Back-off restarting failed container
```

When I terminated the Onload users, the module loader eventually succeeded:
```console
$ oc get pod dev-onload-module-mbv5q-5bzw2 -n openshift-kmm
NAME                            READY   STATUS    RESTARTS      AGE
dev-onload-module-mbv5q-5bzw2   1/1     Running   4 (14m ago)   16m
```

‼ NOTE In the test, it doesn't matter if the Onload drivers are removed manually because the module loader pre-stop hooks (that unload drivers) run _even if the post-start hook fails_. It's a generic pod's lifecycle-specific behaviour, not KMM.