### PR TITLE
ON-14968: Support Kustomize "namespace" in Onload

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ E.g. OpenShift 4.10.62 -> 4.10.0
 
 ### Onload manifests
 
-Create and apply the composed Kustomize manifest that defines Onload resources, including namespaces:
+Create and apply the composed Kustomize manifest that defines Onload resources:
 
 ```
 $ oc apply -f onload/imagestream/imagestream.yaml
+$ oc new-project onload-runtime
 $ oc apply [--dry-run=client] -k onload/dev
-$ oc start-build dev-onload-device-plugin -n onload-device-plugin --from-dir onload/deviceplugin
+$ oc start-build dev-onload-device-plugin -n onload-runtime --from-dir onload/deviceplugin
 ```
+
+The `onload-runtime` name of namespace and project is configurable. The users who change it, also need to patch the `namespace` field in the corresponding "kustomization.yaml" file, e.g. "onload/dev/kustomization.yaml" in the above case.
 
 ### Disable chronyd
 
@@ -109,6 +112,7 @@ $ oc delete -f examples/cns-sfnettest.yaml
 $ oc delete project sfptpd
 $ oc delete -f 99-worker-chronyd.yaml
 $ oc delete -k onload/dev
+$ oc delete project onload-runtime
 $ oc delete -f onload/imagestream/imagestream.yaml
 $ oc delete -f sfc/mco/99-sfc-machineconfig.yaml
 ```

--- a/onload/base/kustomization.yaml
+++ b/onload/base/kustomization.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: onload-runtime
 resources:
 - ../kmm/
 - ../userbuild/

--- a/onload/cplane/cplane.yaml
+++ b/onload/cplane/cplane.yaml
@@ -1,21 +1,14 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: onload-cplane
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: onload-cplane-sa
-  namespace: onload-cplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: onload-cplane-role
-  namespace: onload-cplane
 rules:
 - apiGroups:
   - security.openshift.io
@@ -30,7 +23,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: onload-cplane-rb
-  namespace: onload-cplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -43,7 +35,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: onload-cplane-ds
-  namespace: onload-cplane
 spec:
   selector:
     matchLabels:

--- a/onload/dev/kustomization.yaml
+++ b/onload/dev/kustomization.yaml
@@ -10,8 +10,8 @@ patches:
 
 # Onload KMM debug build
 - target:
-    namespace: openshift-kmm
     kind: Module
+    name: onload-module
   patch: |
     - op: replace
       path: /spec/moduleLoader/container/kernelMappings/0/build/buildArgs/0/value
@@ -19,8 +19,8 @@ patches:
 
 # Onload userspace debug build
 - target:
-    namespace: onload-user
     kind: BuildConfig
+    name: onload-user
   patch: |
     - op: add
       path: /spec/strategy/dockerStrategy/buildArgs/0/value

--- a/onload/deviceplugin/0000-buildconfig.yaml
+++ b/onload/deviceplugin/0000-buildconfig.yaml
@@ -1,17 +1,11 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: onload-device-plugin
----
 apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   labels:
     app: onload-device-plugin
   name: onload-device-plugin
-  namespace: onload-device-plugin
 spec:
   nodeSelector:
     node-role.kubernetes.io/worker: ""

--- a/onload/deviceplugin/1000-deviceplugin.yaml
+++ b/onload/deviceplugin/1000-deviceplugin.yaml
@@ -4,13 +4,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: onload-device-plugin-sa
-  namespace: onload-device-plugin
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: onload-device-plugin-role
-  namespace: onload-device-plugin
 rules:
 - apiGroups:
   - security.openshift.io
@@ -25,7 +23,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: onload-device-plugin-rb
-  namespace: onload-device-plugin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -40,7 +37,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: onload-device-plugin-ds
-  namespace: onload-device-plugin
 spec:
   selector:
     matchLabels:

--- a/onload/imagestream/imagestream.yaml
+++ b/onload/imagestream/imagestream.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: system:image-puller
+  name: system:image-builder
   namespace: onload-artifacts
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/onload/kmm/kustomization.yaml
+++ b/onload/kmm/kustomization.yaml
@@ -10,4 +10,4 @@ configMapGenerator:
   files:
   - dockerfile=Dockerfile
 configurations:
-- module-dockerfile-nameref.yaml
+- module-nameref.yaml

--- a/onload/kmm/kustomization.yaml
+++ b/onload/kmm/kustomization.yaml
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: openshift-kmm
 resources:
 - onload-module.yaml
 configMapGenerator:

--- a/onload/kmm/module-nameref.yaml
+++ b/onload/kmm/module-nameref.yaml
@@ -5,3 +5,7 @@ nameReference:
   fieldSpecs:
   - path: spec/moduleLoader/container/kernelMappings/build/dockerfileConfigMap
     kind: Module
+- kind: ServiceAccount
+  fieldSpecs:
+  - path: spec/moduleLoader/serviceAccountName
+    kind: Module

--- a/onload/kmm/onload-module.yaml
+++ b/onload/kmm/onload-module.yaml
@@ -13,7 +13,7 @@ spec:
         - '--first-time'
       kernelMappings:
         - regexp: '^.*\.x86_64$'
-          containerImage: image-registry.openshift-image-registry.svc:5000/openshift-kmm/onload-module:latest
+          containerImage: image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-module:latest
           build:
             dockerfileConfigMap:
               name: onload-module-dockerfile

--- a/onload/kmm/onload-module.yaml
+++ b/onload/kmm/onload-module.yaml
@@ -1,11 +1,43 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: onload-kmm-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: onload-kmm-role
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - privileged
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: onload-kmm-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: onload-kmm-role
+subjects:
+- kind: ServiceAccount
+  name: onload-kmm-sa
+---
 apiVersion: kmm.sigs.x-k8s.io/v1beta1
 kind: Module
 metadata:
   name: onload-module
 spec:
   moduleLoader:
+    serviceAccountName: onload-kmm-sa
     container:
       modprobe:
         moduleName: onload

--- a/onload/userbuild/buildconfig.yaml
+++ b/onload/userbuild/buildconfig.yaml
@@ -1,17 +1,11 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: onload-user
----
 apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   labels:
     app: onload-user
   name: onload-user
-  namespace: onload-user
 spec:
   nodeSelector:
     node-role.kubernetes.io/worker: ""


### PR DESCRIPTION
A series of small patches to decouple the Onload OCP resources (module, UL, CP DS, device plugin) from their initial (individual) namespaces so that now it's managed by Kustomize, which puts all resources in a single configurable namespace.

My choice of a name was `onload-runtime` as the default namespace. (Another namespace is `onload-artifacts` for the images, which was introduced in one of the earlier PRs.)

Additionally, updated README and other small fixes.

---

Testing in OCP v4.12.

Created an image stream:
```console
$ oc apply -f onload/imagestream/imagestream.yaml
namespace/onload-artifacts created
rolebinding.rbac.authorization.k8s.io/system:image-puller created
imagestream.image.openshift.io/onload-user created
imagestream.image.openshift.io/onload-device-plugin created
```

Created a new project:
```console
$ oc new-project onload-runtime
Already on project "onload-runtime" on server "https://api.test.kube.test:6443".

You can add applications to this project with the 'new-app' command. For example, try:

    oc new-app rails-postgresql-example

to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:

    kubectl create deployment hello-node --image=k8s.gcr.io/e2e-test-images/agnhost:2.33 -- /agnhost serve-hostname
```

Created Onload resources:
```console
$ oc apply -k onload/dev
serviceaccount/dev-onload-cplane-sa created
serviceaccount/dev-onload-device-plugin-sa created
serviceaccount/dev-onload-kmm-sa created
role.rbac.authorization.k8s.io/dev-onload-cplane-role created
role.rbac.authorization.k8s.io/dev-onload-device-plugin-role created
role.rbac.authorization.k8s.io/dev-onload-kmm-role created
rolebinding.rbac.authorization.k8s.io/dev-onload-cplane-rb created
rolebinding.rbac.authorization.k8s.io/dev-onload-device-plugin-rb created
rolebinding.rbac.authorization.k8s.io/dev-onload-kmm-rb created
configmap/dev-onload-device-plugin-dockerfile-dg2m94gh7b created
configmap/dev-onload-module-dockerfile-md42g59452 created
configmap/dev-onload-user-dockerfile-7ftgcm9bht created
daemonset.apps/dev-onload-cplane-ds created
daemonset.apps/dev-onload-device-plugin-ds created
buildconfig.build.openshift.io/dev-onload-device-plugin created
buildconfig.build.openshift.io/dev-onload-user created
module.kmm.sigs.x-k8s.io/dev-onload-module created
```

Kicked off the device plugin build:
```console
$ sleep 120 ; oc start-build dev-onload-device-plugin -n onload-runtime --from-dir onload/deviceplugin
Uploading directory "onload/deviceplugin" as binary input for the build ...

Uploading finished
build.build.openshift.io/dev-onload-device-plugin-1 started
```

Checked the running pods (eventually):
```console
$ oc get pod
NAME                                READY   STATUS      RESTARTS        AGE
dev-onload-cplane-ds-jp6xm          1/1     Running     2 (9m40s ago)   9m41s
dev-onload-cplane-ds-qtnxw          1/1     Running     2 (9m35s ago)   9m41s
dev-onload-device-plugin-1-build    0/1     Completed   0               9m17s
dev-onload-device-plugin-ds-99n9q   1/1     Running     0               9m41s
dev-onload-device-plugin-ds-xlghs   1/1     Running     0               9m41s
dev-onload-module-gqdr6-65m5w       1/1     Running     0               9m40s
dev-onload-module-gqdr6-t95bd       1/1     Running     0               9m40s
dev-onload-user-1-build             0/1     Completed   0               9m40s
```