### PR TITLE
ON-14920: Reduce example pods capabilities

### DIFF
--- a/examples/cns-sfnettest.yaml
+++ b/examples/cns-sfnettest.yaml
@@ -51,8 +51,9 @@ metadata:
 spec:
   restartPolicy: Always
   securityContext:
-    allowPrivilegeEscalation: false
-    runAsUser: 0
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: onload-sfnettest-server
     image: image-registry.openshift-image-registry.svc:5000/default/onload-sfnettest:latest
@@ -63,7 +64,10 @@ spec:
       limits:
         amd.com/onload: 1
     securityContext:
-      privileged: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
   nodeName: compute-0
 ---
 apiVersion: v1
@@ -76,8 +80,9 @@ metadata:
 spec:
   restartPolicy: Never
   securityContext:
-    allowPrivilegeEscalation: false
-    runAsUser: 0
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: onload-sfnettest-client
     image: image-registry.openshift-image-registry.svc:5000/default/onload-sfnettest:latest
@@ -88,5 +93,8 @@ spec:
       limits:
         amd.com/onload: 1
     securityContext:
-      privileged: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
   nodeName: compute-1

--- a/onload/deviceplugin/1000-deviceplugin.yaml
+++ b/onload/deviceplugin/1000-deviceplugin.yaml
@@ -65,7 +65,13 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["cp", "-TRv", "/opt/onload", "/host/onload"]
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e;
+                cp -TRv /opt/onload /host/onload;
+                chcon --verbose --type container_file_t --recursive /host/onload/;
       volumes:
         - hostPath:
             path: /var/lib/kubelet/device-plugins

--- a/onload/deviceplugin/1000-deviceplugin.yaml
+++ b/onload/deviceplugin/1000-deviceplugin.yaml
@@ -72,6 +72,14 @@ spec:
                 set -e;
                 cp -TRv /opt/onload /host/onload;
                 chcon --verbose --type container_file_t --recursive /host/onload/;
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e;
+                rm -r /opt/onload /host/onload;
       volumes:
         - hostPath:
             path: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
#### [1/3] ON-14920: Fix SELinux context for Onload files

Set the `container_file_t` type for all files in `/opt/onload` in the compute nodes from the device plugin DS.

The device plugin DS copies Onload files from the UL build image into the node filesystem, ready for use in the user pods when they request the relevant resources with `resources.limits.amd.com/onload: 1`. However, SELinux refuses to grant access to these files to unprivileged pods because they have a wrong `type` in the SELinux `user:role:type:level`. The pods have the `container_file_t` type, but the Onload files have the `var_t` type.

To address the mismatch, the device plugin DS runs `chcon` to set the type in `/opt/onload` recursively.

Note that the `chcon` changes are not permanent and will be reset in the next autorelabel with SELinux. This patch operates on the assumption that autorelabel is a heavyweight operation and occurs only as part of node maintenance, i.e., outside our DS's lifespan. If we discover that this assumption is wrong, we should consider using `semanage fcontext` for permanent changes. It may require a more involved fix, like a new MachineConfig because it implies changes to the node system files, i.e. in `/etc/selinux/`.

#### [2/3] ON-14920: Reduce example pods capabilities

The previous patch that addresses SELinux allows us to reduce the pod capabilities.

#### [3/3] cleanup: Remove Onload files from nodes on device plugin exit

---

Testing notes.

Before applying the patches, the (unprivileged) example pods could not access the files (pod shell):
```console
sh-4.4$ ls -l /opt/onload/usr/lib64/
total 0
-????????? ? ? ? ?            ? libonload.so
-????????? ? ? ? ?            ? libonload_ext.so
-????????? ? ? ? ?            ? libonload_ext.so.1
-????????? ? ? ? ?            ? libonload_ext.so.1.2.0
```

The node audit logs confirm the issue is SELinux-context related (node shell):

```console
# ausearch -m avc --start recent
----
time->Tue Jun 27 14:52:32 2023
type=PROCTITLE msg=audit(1687877552.264:593): proctitle=2F7573722F62696E2F636F72657574696C73002D2D636F72657574696C732D70726F672D73686562616E673D6C73002F7573722F62696E2F6C73002D6C002F6F70742F6F6E6C6F61642F7573722F6C696236342F
type=SYSCALL msg=audit(1687877552.264:593): arch=c000003e syscall=257 success=no exit=-13 a0=ffffff9c a1=7eff34bc00f0 a2=80000 a3=0 items=0 ppid=459748 pid=459963 auid=4294967295 uid=1000 gid=0 euid=1000 suid=1000 fsuid=1000 egid=0 sgid=0 fsgid=0 tty=pts0 ses=4294967295 comm="ls" exe="/usr/bin/coreutils" subj=system_u:system_r:container_t:s0:c161,c625 key=(null)
type=AVC msg=audit(1687877552.264:593): avc:  denied  { read } for  pid=459963 comm="ls" name="libonload.so" dev="vda4" ino=15066390 scontext=system_u:system_r:container_t:s0:c161,c625 tcontext=system_u:object_r:var_t:s0 tclass=file permissive=0
```

After applying the patches (pod shell):
```
sh-4.4$ ls -l /opt/onload/usr/lib64/
total 12460
-rwxr-xr-x. 1 root root 12672720 Jun 27 16:57 libonload.so
-rwxr-xr-x. 1 root root    27416 Jun 27 16:57 libonload_ext.so
-rwxr-xr-x. 1 root root    27416 Jun 27 16:57 libonload_ext.so.1
-rwxr-xr-x. 1 root root    27416 Jun 27 16:57 libonload_ext.so.1.2.0
```

Also, since the pods are no longer privileged, OCP does not issue warnings (`oc` user shell):
```console
$ oc apply -f examples/cns-sfnettest.yaml
imagestream.image.openshift.io/onload-sfnettest unchanged
buildconfig.build.openshift.io/onload-sfnettest configured
pod/onload-sfnettest-server created
pod/onload-sfnettest-client created
```