### PR TITLE
cleanup: Trigger device plugin build automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Create and apply the composed Kustomize manifest that defines Onload resources:
 $ oc apply -f onload/imagestream/imagestream.yaml
 $ oc new-project onload-runtime
 $ oc apply [--dry-run=client] -k onload/dev
-$ oc start-build dev-onload-device-plugin -n onload-runtime --from-dir onload/deviceplugin
 ```
 
 The `onload-runtime` name of namespace and project is configurable. The users who change it, also need to patch the `namespace` field in the corresponding "kustomization.yaml" file, e.g. "onload/dev/kustomization.yaml" in the above case.

--- a/onload/deviceplugin/0000-buildconfig.yaml
+++ b/onload/deviceplugin/0000-buildconfig.yaml
@@ -10,6 +10,14 @@ spec:
   nodeSelector:
     node-role.kubernetes.io/worker: ""
   runPolicy: "Serial"
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChange:
+        from:
+          kind: ImageStreamTag
+          name: onload-user:latest
+          namespace: onload-artifacts
   source:
     dockerfile: (placeholder)
 

--- a/onload/deviceplugin/Dockerfile
+++ b/onload/deviceplugin/Dockerfile
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 FROM golang:1.20.4 AS builder
-COPY . /app/
+
 WORKDIR /app
+RUN git clone --depth 1 https://github.com/Xilinx-CNS/kubernetes-onload.git
+
+WORKDIR /app/kubernetes-onload/onload/deviceplugin
 RUN go build -o /app/onload-plugin
 
 FROM image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-user:latest


### PR DESCRIPTION
Add build triggers to the Onload device plugin.

We couldn't anonymously pull the device plugin sources from the internet until we published this repository. Instead, we (temporarily) asked the user to trigger the device plugin build locally/manually with `oc start-build ... --from-dir ...`. Now, we can pull the sources, so this patch instantiates the triggers.

Because the device plugin image is based on the Onload UL build image, the trigger specifically refers to the onload-user ImageStreamTag to retrigger the build as soon as the new Onload UL image is available.

When all Onload resources are created simultaneously, e.g. with Kustomize, the UL build may not be available, and it may cause the early device plugin builds to fail, but once UL is ready, the build restarts and succeeds.

---

(Testing notes) Applied the composed Kustomize manifest and waited until:

```console
$ oc get pod -n onload-runtime
NAME                                READY   STATUS      RESTARTS       AGE
dev-onload-cplane-ds-bjrx9          1/1     Running     5 (110s ago)   6m2s
dev-onload-cplane-ds-nk6tz          1/1     Running     5 (108s ago)   6m2s
dev-onload-device-plugin-1-build    0/1     Error       0              6m1s
dev-onload-device-plugin-2-build    0/1     Completed   0              4m9s
dev-onload-device-plugin-ds-nzwkz   1/1     Running     0              6m2s
dev-onload-device-plugin-ds-vl9b2   1/1     Running     0              6m2s
dev-onload-module-mrxwl-fjrt2       1/1     Running     0              84s
dev-onload-module-mrxwl-mnlb9       1/1     Running     0              84s
dev-onload-module-vp545-build       0/1     Completed   0              6m1s
dev-onload-user-1-build             0/1     Completed   0              6m1s
```

The first build failed because the Onload UL wasn't available, but the second was triggered as soon as the Onload UL was built.