### PR TITLE
cleanup: Rename onload-artifacts to onload-clusterlocal

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ $ oc new-project onload-runtime
 $ oc apply [--dry-run=client] -k onload/dev
 ```
 
-The `onload-runtime` name of namespace and project is configurable. The users who change it, also need to patch the `namespace` field in the corresponding "kustomization.yaml" file, e.g. "onload/dev/kustomization.yaml" in the above case.
+The "onload/imagestream/imagestream.yaml" manifest will create the new `onload-clusterlocal` namespace for ImageStream(s), referring to the Onload resources built locally in the cluster.
+
+Another `onload-runtime` namespace is configurable. The users who change it, also need to patch the `namespace` field in the corresponding "kustomization.yaml" file, e.g. "onload/dev/kustomization.yaml" in the above case.
 
 ### Disable chronyd
 

--- a/onload/cplane/cplane.yaml
+++ b/onload/cplane/cplane.yaml
@@ -53,7 +53,7 @@ spec:
       hostIPC: true
       containers:
       - name: onload-cplane
-        image: image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-user:git27b3826
+        image: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-user:git27b3826
         imagePullPolicy: Always
         command:
         - /bin/sh

--- a/onload/deviceplugin/0000-buildconfig.yaml
+++ b/onload/deviceplugin/0000-buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
         from:
           kind: ImageStreamTag
           name: onload-user:git27b3826
-          namespace: onload-artifacts
+          namespace: onload-clusterlocal
   source:
     dockerfile: (placeholder)
 
@@ -28,4 +28,4 @@ spec:
     to:
       kind: ImageStreamTag
       name: onload-device-plugin:latest
-      namespace: onload-artifacts
+      namespace: onload-clusterlocal

--- a/onload/deviceplugin/1000-deviceplugin.yaml
+++ b/onload/deviceplugin/1000-deviceplugin.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccount: onload-device-plugin-sa
       serviceAccountName: onload-device-plugin-sa
       containers:
-      - image: image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-device-plugin:latest
+      - image: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-device-plugin:latest
         name: onload-device-plugin
         imagePullPolicy: Always
         command: ["/usr/bin/onload-plugin"]

--- a/onload/deviceplugin/Dockerfile
+++ b/onload/deviceplugin/Dockerfile
@@ -8,7 +8,7 @@ RUN git clone --depth 1 https://github.com/Xilinx-CNS/kubernetes-onload.git
 WORKDIR /app/kubernetes-onload/onload/deviceplugin
 RUN go build -o /app/onload-plugin
 
-FROM image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-user:git27b3826
+FROM image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-user:git27b3826
 RUN microdnf install lshw
 COPY --from=builder /app/onload-plugin /usr/bin/onload-plugin
 CMD ["/usr/bin/onload-plugin"]

--- a/onload/imagestream/imagestream.yaml
+++ b/onload/imagestream/imagestream.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: onload-artifacts
+  name: onload-clusterlocal
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: system:image-builder
-  namespace: onload-artifacts
+  namespace: onload-clusterlocal
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -23,12 +23,12 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: onload-user
-  namespace: onload-artifacts
+  namespace: onload-clusterlocal
 spec: {}
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: onload-device-plugin
-  namespace: onload-artifacts
+  namespace: onload-clusterlocal
 spec: {}

--- a/onload/kmm/onload-module.yaml
+++ b/onload/kmm/onload-module.yaml
@@ -45,7 +45,7 @@ spec:
         - '--first-time'
       kernelMappings:
         - regexp: '^.*\.x86_64$'
-          containerImage: image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-module:git27b3826-${KERNEL_FULL_VERSION}
+          containerImage: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-module:git27b3826-${KERNEL_FULL_VERSION}
           build:
             dockerfileConfigMap:
               name: onload-module-dockerfile

--- a/onload/userbuild/buildconfig.yaml
+++ b/onload/userbuild/buildconfig.yaml
@@ -26,4 +26,4 @@ spec:
     to:
       kind: ImageStreamTag
       name: onload-user:git27b3826
-      namespace: onload-artifacts
+      namespace: onload-clusterlocal


### PR DESCRIPTION
We are contrasting against official Onload images, therefore renaming to onload-clusterlocal.

Suggested-by: Peter Colledge <peter.colledge@amd.com>