### PR TITLE
ON-15010: Use a fixed tag for onload builds

### DIFF
--- a/onload/cplane/cplane.yaml
+++ b/onload/cplane/cplane.yaml
@@ -53,7 +53,7 @@ spec:
       hostIPC: true
       containers:
       - name: onload-cplane
-        image: image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-user:latest
+        image: image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-user:git27b3826
         imagePullPolicy: Always
         command:
         - /bin/sh

--- a/onload/deviceplugin/0000-buildconfig.yaml
+++ b/onload/deviceplugin/0000-buildconfig.yaml
@@ -16,7 +16,7 @@ spec:
       imageChange:
         from:
           kind: ImageStreamTag
-          name: onload-user:latest
+          name: onload-user:git27b3826
           namespace: onload-artifacts
   source:
     dockerfile: (placeholder)

--- a/onload/deviceplugin/Dockerfile
+++ b/onload/deviceplugin/Dockerfile
@@ -8,7 +8,7 @@ RUN git clone --depth 1 https://github.com/Xilinx-CNS/kubernetes-onload.git
 WORKDIR /app/kubernetes-onload/onload/deviceplugin
 RUN go build -o /app/onload-plugin
 
-FROM image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-user:latest
+FROM image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-user:git27b3826
 RUN microdnf install lshw
 COPY --from=builder /app/onload-plugin /usr/bin/onload-plugin
 CMD ["/usr/bin/onload-plugin"]

--- a/onload/kmm/Dockerfile
+++ b/onload/kmm/Dockerfile
@@ -4,12 +4,14 @@ ARG DTK_AUTO
 
 FROM ${DTK_AUTO} as builder
 ARG ONLOAD_BUILD_PARAMS
+ARG ONLOAD_VERSION
 ARG KERNEL_VERSION
 
 WORKDIR /build/
-RUN git clone --depth 1 https://github.com/Xilinx-CNS/onload.git
-
-WORKDIR /build/onload
+ADD https://github.com/Xilinx-CNS/onload/archive/${ONLOAD_VERSION}.tar.gz onload.tar.gz
+RUN mkdir -p /build/onload
+RUN tar xzf onload.tar.gz -C /build/onload --strip-components=1
+WORKDIR /build/onload/
 
 RUN scripts/onload_build --kernel --kernelver ${KERNEL_VERSION} ${ONLOAD_BUILD_PARAMS}
 RUN scripts/onload_install --nobuild --kernelfiles --kernelver ${KERNEL_VERSION}

--- a/onload/kmm/onload-module.yaml
+++ b/onload/kmm/onload-module.yaml
@@ -45,12 +45,14 @@ spec:
         - '--first-time'
       kernelMappings:
         - regexp: '^.*\.x86_64$'
-          containerImage: image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-module:latest
+          containerImage: image-registry.openshift-image-registry.svc:5000/onload-artifacts/onload-module:git27b3826-${KERNEL_FULL_VERSION}
           build:
             dockerfileConfigMap:
               name: onload-module-dockerfile
             buildArgs:
             - name: ONLOAD_BUILD_PARAMS
               value: ""
+            - name: ONLOAD_VERSION
+              value: 27b38261cfc394012413ee6cbeef8f1ae781489c
   selector: # top-level selector
     kubernetes.io/arch: amd64

--- a/onload/userbuild/Dockerfile
+++ b/onload/userbuild/Dockerfile
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 FROM registry.redhat.io/ubi8/ubi-minimal as builder
 ARG ONLOAD_BUILD_PARAMS
+ARG ONLOAD_VERSION
 
 # Install requirements for building onload userland
 RUN microdnf install -y binutils \
@@ -37,10 +38,10 @@ RUN rpm -i libcap-*.src.rpm \
 # END
 
 # Build onload userland components
-WORKDIR /build/
-RUN git clone https://github.com/Xilinx-CNS/onload.git
-
-WORKDIR /build/onload
+ADD https://github.com/Xilinx-CNS/onload/archive/${ONLOAD_VERSION}.tar.gz onload.tar.gz
+RUN mkdir -p /build/onload
+RUN tar xzf onload.tar.gz -C /build/onload --strip-components=1
+WORKDIR /build/onload/
 RUN scripts/onload_build --user ${ONLOAD_BUILD_PARAMS}
 
 RUN mkdir /opt/onload

--- a/onload/userbuild/buildconfig.yaml
+++ b/onload/userbuild/buildconfig.yaml
@@ -20,8 +20,10 @@ spec:
       buildArgs:
       - name: ONLOAD_BUILD_PARAMS
         value:
+      - name: ONLOAD_VERSION
+        value: 27b38261cfc394012413ee6cbeef8f1ae781489c
   output:
     to:
       kind: ImageStreamTag
-      name: onload-user:latest
+      name: onload-user:git27b3826
       namespace: onload-artifacts

--- a/sfc/kmm/sfc-module.yaml
+++ b/sfc/kmm/sfc-module.yaml
@@ -12,12 +12,14 @@ data:
     FROM ${DTK_AUTO} as builder
 
     ARG KERNEL_VERSION
+    ARG ONLOAD_VERSION
 
     WORKDIR /build/
 
-    RUN git clone --depth 1 https://github.com/Xilinx-CNS/onload.git
-
-    WORKDIR /build/onload
+    ADD https://github.com/Xilinx-CNS/onload/archive/${ONLOAD_VERSION}.tar.gz onload.tar.gz
+    RUN mkdir -p /build/onload
+    RUN tar xzf onload.tar.gz -C /build/onload --strip-components=1
+    WORKDIR /build/onload/
 
     # Currently there are issues regarding when building the sfc driver due to
     # differences between the DTK image used for building and the ubi image used
@@ -53,9 +55,12 @@ spec:
         moduleName: sfc
       kernelMappings:
         - regexp: '^.*\.x86_64$'
-          containerImage: image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:${KERNEL_FULL_VERSION}
+          containerImage: image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:git27b3826-${KERNEL_FULL_VERSION}
           build:
             dockerfileConfigMap:
               name: sfc-module-dockerfile
+            buildArgs:
+            - name: ONLOAD_VERSION
+              value: 27b38261cfc394012413ee6cbeef8f1ae781489c
   selector: # top-level selector
     kubernetes.io/arch: amd64


### PR DESCRIPTION
We want to avoid using `latest` as a tag for our produced images.
Since running onload in a cluster is dependent on any new developments for onload, I think it should be fine to use a fixed tag to pull from github.

This doesn't touch `onload-device-plugin` or `sfnettest` images

## Testing done

Builds and runs in a 4.12.12 cluster