### PR TITLE
fix: Set default user 1001 for sfnettest image

### DIFF
--- a/examples/sfnettest/cns-sfnettest.yaml
+++ b/examples/sfnettest/cns-sfnettest.yaml
@@ -36,6 +36,8 @@ spec:
       WORKDIR /build/cns-sfnettest/src
       RUN make
 
+      USER 1001
+
   strategy:
     dockerStrategy:
       buildArgs:


### PR DESCRIPTION
The "sfnettest" pod re-uses the default "ubi8/ubi-init" user, which is the root, and it conflicts with the pod restriction "runAsNonRoot". It causes the CreateContainerConfigError and prevents the pod from starting.

To address the error, this patch overrides the default user with 1001.

Reported-by: James Jay <jjay@xilinx.com>

---

Testing:
```
$ oc apply -k examples/profiles/latency/
```
Then (once the build it complete, in the default namespace):
```console
$ oc get pod
NAME                       READY   STATUS      RESTARTS   AGE
onload-sfnettest-1-build   0/1     Completed   0          11m
onload-sfnettest-client    1/1     Running     0          10s
onload-sfnettest-server    1/1     Running     0          10s
```

---

Why 1001? It seems like the recommended practice. I also peeked into a few images, e.g. ubi9/httpd-24:

```console
$ oc describe image sha256:354752e701888ab641207c0626b1e7e9ff1388d5f2dea667799c7ad0e0b81b43 | grep -e 'User' -e 'Docker Image'
Docker Image:   registry.redhat.io/ubi9/httpd-24@sha256:354752e701888ab641207c0626b1e7e9ff1388d5f2dea667799c7ad0e0b81b43
User:           1001
```

dotnet/dotnet-31-runtime-rhel7:
```console
$ oc describe image sha256:58720198f64c1870adbba6e252ce6cf966088db9c0001f9877e71346143fa3cf | grep -e 'User' -e 'Docker Image'
Docker Image:   registry.redhat.io/dotnet/dotnet-31-runtime-rhel7@sha256:58720198f64c1870adbba6e252ce6cf966088db9c0001f9877e71346143fa3cf
User:           1001
```

ubi9/nginx-120:
```console
$ oc describe image sha256:84e1cd9c5b20e3336662c190b488fdee2fbc40a48a81915a1ee97556eba5976a | grep -e 'User' -e 'Docker Image'
Docker Image:   registry.redhat.io/ubi9/nginx-120@sha256:84e1cd9c5b20e3336662c190b488fdee2fbc40a48a81915a1ee97556eba5976a
User:           1001
```