### PR TITLE
ON-14971: Use correct sfc-module image tags in mc scripts

### DIFF
--- a/sfc/mco/sfc-pull-kernel-module-image.sh
+++ b/sfc/mco/sfc-pull-kernel-module-image.sh
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 
-if podman image exists image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:$(uname -r); then
+if podman image exists image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:git27b3826-$(uname -r); then
     echo "Image sfc-module found in the local registry.Nothing to do"
 else
     echo "Image sfc-module not found in the local registry, pulling"
-    podman pull --authfile /var/lib/kubelet/config.json image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:$(uname -r)
+    podman pull --authfile /var/lib/kubelet/config.json image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:git27b3826-$(uname -r)
     if [ $? -eq 0 ]; then
         echo "Image sfc-module has been successfully pulled, rebooting.."
         reboot

--- a/sfc/mco/sfc-replace-kernel-module.sh
+++ b/sfc/mco/sfc-replace-kernel-module.sh
@@ -3,10 +3,10 @@
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 echo "before checking podman images"
-if podman image exists image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:$(uname -r); then
+if podman image exists image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:git27b3826-$(uname -r); then
     echo "Image sfc-module found in the local registry, removing in-tree kernel module"
 
-    podman run --privileged --entrypoint modprobe image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:$(uname -r) -rd /opt sfc sfc_driverlink
+    podman run --privileged --entrypoint modprobe image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:git27b3826-$(uname -r) -rd /opt sfc sfc_driverlink
     if [ $? -eq 0 ]; then
             echo "Successfully removed the in-tree kernel module sfc.ko"
     else
@@ -14,7 +14,7 @@ if podman image exists image-registry.openshift-image-registry.svc:5000/openshif
     fi
 
     echo "Running container image to insert the oot kernel module sfc.ko"
-    podman run --privileged --entrypoint modprobe image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:$(uname -r) -d /opt sfc
+    podman run --privileged --entrypoint modprobe image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:git27b3826-$(uname -r) -d /opt sfc
     if [ $? -eq 0 ]; then
             echo "OOT kernel module sfc.ko is inserted"
     else


### PR DESCRIPTION
Without this change the machineconfig scripts would try to pull a non-existant image