### PR TITLE
ON-14965: Document sfc OoT driver installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,51 @@ Expected environment:
   - Node Feature Discovery (NFD) Operator
   - Kernel Module Management (KMM) Operator
 
-### SFC MachineConfig
+### SFC out of tree driver
 
-To apply the SFC MachineConfig, it is a prerequisite that there exists a local docker registry containing an image with the SFC module built and present in /opt in the node filesystem. This is expected to be present at the following location:
+The recommended way of installing onload's sfc driver is using [KMM](https://github.com/rh-ecosystem-edge/kernel-module-management/)
+
+#### Deploy using KMM
+
+Before you apply the `Module` custom resource for the SFC driver you must
+remove the existing in-tree driver.
+
+For each appropriate node in the cluster:
+```console
+# rmmod sfc
+```
+
+Then apply the manifest:
+
+```console
+$ oc apply -f sfc/kmm/sfc-module.yaml
+```
+
+#### Day-0 deployment using MachineConfig
+
+To apply the SFC MachineConfig, it is a prerequisite that there exists a local
+docker registry containing an image with the SFC module built and present in
+`/opt` in the node filesystem. This is expected to be present at the following
+location:
 
 ```
 image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module
 ```
 
-To generate this image, please use SFC module:
-```
-$ oc apply -f sfc/kmm/sfc-module.yaml
-```
-
-The generated image must be labelled with the exact kernel version necessary for the worker nodes. All worker nodes must share the same kernel version.
+The generated image must be labelled with the exact kernel version necessary
+for the worker nodes. All worker nodes must share the same kernel version.
 
 Apply the SFC MachineConfig:
 
-```
+```console
 $ butane sfc/mco/99-sfc-machineconfig.bu -d sfc/mco/ -o sfc/mco/99-sfc-machineconfig.yaml
 $ oc apply -f sfc/mco/99-sfc-machineconfig.yaml
 ```
 
-Please ensure that the openshift version specified within the above butane file tracks the appropriate specification revision.
-https://github.com/coreos/butane/blob/main/docs/specs.md#stable-specification-versions
+Please ensure that the OpenShift version specified within the above butane file
+tracks the appropriate specification revision. Stable versions can be checked
+[here](https://github.com/coreos/butane/blob/main/docs/specs.md#stable-specification-versions).
+
 E.g. OpenShift 4.10.62 -> 4.10.0
 
 
@@ -60,8 +81,10 @@ $ butane sfptpd/99-worker-chronyd.bu -o sfptpd/99-worker-chronyd.yaml
 $ oc apply -f sfptpd/99-worker-chronyd.yaml
 ```
 
-Please ensure that the openshift version specified within the above butane file tracks the appropriate specification revision.
-https://github.com/coreos/butane/blob/main/docs/specs.md#stable-specification-versions
+Please ensure that the OpenShift version specified within the above butane file
+tracks the appropriate specification revision. Stable versions can be checked
+[here](https://github.com/coreos/butane/blob/main/docs/specs.md#stable-specification-versions).
+
 E.g. OpenShift 4.10.62 -> 4.10.0
 
 
@@ -113,9 +136,17 @@ $ oc delete -f 99-worker-chronyd.yaml
 $ oc delete -k onload/dev
 $ oc delete project onload-runtime
 $ oc delete -f onload/imagestream/imagestream.yaml
-$ oc delete -f sfc/mco/99-sfc-machineconfig.yaml
 ```
 
+To remove SFC Module:
+```console
+$ oc delete -f sfc/kmm/sfc-module.yaml
+```
+
+To remove SFC MachineConfig
+```console
+$ oc delete -f sfc/mco/99-sfc-machineconfig.yaml
+```
 (Applying and removing MachineConfig might reboot the targeted nodes.)
 
 Make sure the Onload kernel modules are unloaded, i.e. by running directly in the worker nodes:


### PR DESCRIPTION
Previous versions of `README.md` only properly documented how to install the sfc MachineConfig, now it has appropriate instructions for both KMM and MCO