### PR TITLE
ON-15020: Use kustomize to deploy SFC KMM

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For each appropriate node in the cluster:
 Then apply the manifest:
 
 ```console
-$ oc apply -f sfc/kmm/sfc-module.yaml
+$ oc apply -k sfc/kmm/
 ```
 
 #### Day-0 deployment using MachineConfig
@@ -140,7 +140,7 @@ $ oc delete -f onload/imagestream/imagestream.yaml
 
 To remove SFC Module:
 ```console
-$ oc delete -f sfc/kmm/sfc-module.yaml
+$ oc delete -k sfc/kmm/
 ```
 
 To remove SFC MachineConfig

--- a/sfc/kmm/Dockerfile
+++ b/sfc/kmm/Dockerfile
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+ARG DTK_AUTO
+FROM ${DTK_AUTO} as builder
+
+ARG KERNEL_VERSION
+ARG ONLOAD_VERSION
+
+WORKDIR /build/
+
+ADD https://github.com/Xilinx-CNS/onload/archive/${ONLOAD_VERSION}.tar.gz onload.tar.gz
+RUN mkdir -p /build/onload
+RUN tar xzf onload.tar.gz -C /build/onload --strip-components=1
+WORKDIR /build/onload/
+
+# Currently there are issues regarding when building the sfc driver due to
+# differences between the DTK image used for building and the ubi image used
+# for loading the drivers.
+#
+# Issues found are with:
+# * vdpa
+# * mtd
+#
+# To prevent building the problematic things we have to pass additional
+# parameters to the driver build. Unfortunately it is currently possible to do
+# this with onload's build scripts, so the driver's Makefile is used directly.
+RUN make -j8 -C src/driver/linux_net CONFIG_SFC_VDPA= CONFIG_SFC_MTD= KVER=${KERNEL_VERSION}
+
+FROM docker.io/redhat/ubi8:latest
+ARG KERNEL_VERSION
+
+RUN yum -y install kmod && yum clean all
+RUN mkdir -p /opt/lib/modules/${KERNEL_VERSION}
+COPY --from=builder /build/onload/src/driver/linux_net/drivers/net/ethernet/sfc/sfc.ko /opt/lib/modules/${KERNEL_VERSION}/
+COPY --from=builder /build/onload/src/driver/linux_net/drivers/net/ethernet/sfc/sfc_driverlink.ko /opt/lib/modules/${KERNEL_VERSION}/
+RUN /usr/sbin/depmod -b /opt

--- a/sfc/kmm/kustomization.yaml
+++ b/sfc/kmm/kustomization.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- sfc-module.yaml
+namespace: openshift-kmm
+configMapGenerator:
+- name: sfc-module-dockerfile
+  files:
+  - dockerfile=Dockerfile
+configurations:
+- module-nameref.yaml

--- a/sfc/kmm/module-nameref.yaml
+++ b/sfc/kmm/module-nameref.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+nameReference:
+- kind: ConfigMap
+  fieldSpecs:
+  - path: spec/moduleLoader/container/kernelMappings/build/dockerfileConfigMap
+    kind: Module

--- a/sfc/kmm/sfc-module.yaml
+++ b/sfc/kmm/sfc-module.yaml
@@ -1,48 +1,5 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: sfc-module-dockerfile
-  namespace: openshift-kmm
-data:
-  dockerfile: |
-    ARG DTK_AUTO
-    FROM ${DTK_AUTO} as builder
-
-    ARG KERNEL_VERSION
-    ARG ONLOAD_VERSION
-
-    WORKDIR /build/
-
-    ADD https://github.com/Xilinx-CNS/onload/archive/${ONLOAD_VERSION}.tar.gz onload.tar.gz
-    RUN mkdir -p /build/onload
-    RUN tar xzf onload.tar.gz -C /build/onload --strip-components=1
-    WORKDIR /build/onload/
-
-    # Currently there are issues regarding when building the sfc driver due to
-    # differences between the DTK image used for building and the ubi image used
-    # for loading the drivers.
-    #
-    # Issues found are with:
-    # * vdpa
-    # * mtd
-    #
-    # To prevent building the problematic things we have to pass additional
-    # parameters to the driver build. Unfortunately it is currently possible to do
-    # this with onload's build scripts, so the driver's Makefile is used directly.
-    RUN make -j8 -C src/driver/linux_net CONFIG_SFC_VDPA= CONFIG_SFC_MTD= KVER=${KERNEL_VERSION}
-
-    FROM docker.io/redhat/ubi8:latest
-    ARG KERNEL_VERSION
-
-    RUN yum -y install kmod && yum clean all
-    RUN mkdir -p /opt/lib/modules/${KERNEL_VERSION}
-    COPY --from=builder /build/onload/src/driver/linux_net/drivers/net/ethernet/sfc/sfc.ko /opt/lib/modules/${KERNEL_VERSION}/
-    COPY --from=builder /build/onload/src/driver/linux_net/drivers/net/ethernet/sfc/sfc_driverlink.ko /opt/lib/modules/${KERNEL_VERSION}/
-    RUN /usr/sbin/depmod -b /opt
----
 apiVersion: kmm.sigs.x-k8s.io/v1beta1
 kind: Module
 metadata:


### PR DESCRIPTION
This allows us to separate out the `Dockerfile` for use with `podman` outside of a cluster.
Additionally, it should allow for multiple kustomizations eg for debug/release versions.

## Testing done
`sfc-module` builds and deploys in cluster.