### PR TITLE
ON-15022: Add onload_mkimages script to build necessary images outside of a cluster using podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ MachineConfig component upon reboot. In KMM v1.1 onwards, add
 rmmod sfc
 ```
 
+_The kustomization patch file [sfc/deploy/patch-sfc-module-no-build.yaml](sfc/deploy/patch-sfc-module-no-build.yaml)
+will attempt to pull the images from the fictional image registry at
+`example.com` this file should be updated with the actual location of the image_
+
 ```console
 $ oc create -k sfc/deploy
 ```
@@ -279,6 +283,12 @@ $ oc apply -f sfc/mco/99-sfc-machineconfig.yaml
 ```
 
 ### Deploying onload
+
+
+_The kustomization file for deploy onload without building [sfc/deploy/kustomization.yaml](sfc/deploy/kustomization.yaml)
+and the patch file for the onload-module CR [sfc/deploy/patch-sfc-module-no-build.yaml](sfc/deploy/patch-sfc-module-no-build.yaml)
+will attempt to pull the images from the fictional image registry at
+`example.com` this should be updated with the actual location of the image_
 
 ```console
 $ oc new-project onload-runtime

--- a/onload/base/kustomization.yaml
+++ b/onload/base/kustomization.yaml
@@ -8,3 +8,11 @@ resources:
 - ../kmm/
 - ../cplane/
 - ../deviceplugin/
+
+images:
+- name: cplane
+  newName: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-user
+  newTag: git27b3826
+- name: device-plugin
+  newName: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-device-plugin
+  newTag: latest

--- a/onload/cplane/cplane.yaml
+++ b/onload/cplane/cplane.yaml
@@ -53,7 +53,7 @@ spec:
       hostIPC: true
       containers:
       - name: onload-cplane
-        image: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-user:git27b3826
+        image: cplane
         imagePullPolicy: Always
         command:
         - /bin/sh

--- a/onload/deploy/kustomization.yaml
+++ b/onload/deploy/kustomization.yaml
@@ -10,3 +10,10 @@ resources:
 patchesStrategicMerge:
 - patch-onload-module-no-build.yaml
 
+images:
+- name: cplane
+  newName: www.example.com/onload-user
+  newTag: enterpriseonload-8.1.0.2
+- name: device-plugin
+  newName: www.example.com/onload-device-plugin
+  newTag: enterpriseonload-8.1.0.2-latest

--- a/onload/deploy/patch-onload-module-no-build.yaml
+++ b/onload/deploy/patch-onload-module-no-build.yaml
@@ -9,5 +9,5 @@ spec:
     container:
       kernelMappings:
         - regexp: '^.*\.x86_64$'
-          containerImage: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-module:git27b3826-${KERNEL_FULL_VERSION}
+          containerImage: www.example.com/onload-module:enterpriseonload-8.1.0.2-${KERNEL_FULL_VERSION}
           build:

--- a/onload/deviceplugin/1000-deviceplugin.yaml
+++ b/onload/deviceplugin/1000-deviceplugin.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccount: onload-device-plugin-sa
       serviceAccountName: onload-device-plugin-sa
       containers:
-      - image: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-device-plugin:latest
+      - image: device-plugin
         name: onload-device-plugin
         imagePullPolicy: Always
         command: ["/usr/bin/onload-plugin"]

--- a/scripts/onload-device-plugin.Dockerfile
+++ b/scripts/onload-device-plugin.Dockerfile
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+ARG ONLOAD_IMAGE
+ARG IMAGE_TAG
+
+FROM docker.io/library/golang:1.20.4 AS builder
+
+WORKDIR /app
+COPY . /app
+
+RUN go build -o /app/onload-plugin
+
+FROM ${ONLOAD_IMAGE}:${IMAGE_TAG}
+RUN microdnf install lshw
+COPY --from=builder /app/onload-plugin /usr/bin/onload-plugin
+CMD ["/usr/bin/onload-plugin"]

--- a/scripts/onload-module.Dockerfile
+++ b/scripts/onload-module.Dockerfile
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+ARG DTK_AUTO
+
+FROM ${DTK_AUTO} as builder
+ARG ONLOAD_BUILD_PARAMS
+ARG ONLOAD_VERSION
+ARG KERNEL_VERSION
+
+WORKDIR /build/
+
+RUN mkdir -p /build/onload
+COPY ${ONLOAD_VERSION} /build
+RUN tar xzf ${ONLOAD_VERSION} -C /build/onload --strip-components=1
+WORKDIR /build/onload/
+
+RUN scripts/onload_build --kernel --kernelver ${KERNEL_VERSION} ${ONLOAD_BUILD_PARAMS}
+RUN scripts/onload_install --nobuild --kernelfiles --kernelver ${KERNEL_VERSION}
+
+FROM registry.access.redhat.com/ubi8/ubi
+ARG KERNEL_VERSION
+
+RUN yum -y install kmod && yum clean all
+RUN mkdir -p /opt/lib/modules/${KERNEL_VERSION}
+
+COPY --from=builder /lib/modules/${KERNEL_VERSION}/extra/onload.* /opt/lib/modules/${KERNEL_VERSION}
+COPY --from=builder /lib/modules/${KERNEL_VERSION}/extra/sfc_char.* /opt/lib/modules/${KERNEL_VERSION}
+COPY --from=builder /lib/modules/${KERNEL_VERSION}/extra/sfc_resource.* /opt/lib/modules/${KERNEL_VERSION}
+
+RUN /usr/sbin/depmod -b /opt ${KERNEL_VERSION}

--- a/scripts/onload-user.Dockerfile
+++ b/scripts/onload-user.Dockerfile
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+FROM registry.redhat.io/ubi8/ubi-minimal as builder
+ARG ONLOAD_BUILD_PARAMS
+ARG ONLOAD_VERSION
+
+# Install requirements for building onload userland
+RUN microdnf install -y binutils \
+gettext \
+gawk \
+gcc \
+sed \
+make \
+bash \
+glibc-common \
+libpcap-devel \
+perl-Test-Harness \ 
+gcc-c++ \
+git \
+make \
+which \
+python3-devel \
+kmod \
+tar \
+libcap-devel
+
+# libcap headers are needed to build onload. The installation of the
+# headers on RHEL is normally handled by installing the rpm package libcap-devel.
+# However, that package is not available in the standard ubi8
+# package repositories, so to get around this issue the package is
+# downloaded, built and installed manually.
+# START
+RUN microdnf -y --enablerepo=ubi-8-baseos-source download --source libcap
+
+RUN mkdir libcap
+RUN rpm -i libcap-*.src.rpm \
+ && tar xzf ~/rpmbuild/SOURCES/libcap-*.tar.gz --strip-components=1 -C libcap \
+ && make -C libcap/libcap install
+# END
+WORKDIR /build/
+
+# Build onload userland components
+RUN mkdir -p /build/onload
+COPY ${ONLOAD_VERSION} /build
+RUN tar xzf ${ONLOAD_VERSION} -C /build/onload --strip-components=1
+WORKDIR /build/onload/
+
+RUN scripts/onload_build --user ${ONLOAD_BUILD_PARAMS}
+
+RUN mkdir /opt/onload
+ENV i_prefix=/opt/onload
+
+RUN scripts/onload_install --nobuild --userfiles
+
+# Prepare a minimal image with onload userland
+FROM registry.redhat.io/ubi8/ubi-minimal
+
+COPY --from=builder /opt/onload /opt/onload
+
+ENTRYPOINT cp -TRv /opt/onload /tmp/onload

--- a/scripts/onload_mkimages.sh
+++ b/scripts/onload_mkimages.sh
@@ -1,0 +1,190 @@
+#! /bin/bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+me="$(basename "$0")"
+
+err()  { echo >&2 "$*"; }
+log()  { err "$me: $*"; }
+fail() { log "$*"; exit 1; }
+try()  { "$@" || fail "FAILED: $*"; }
+tryquiet()  { "$@" >/dev/null || fail "FAILED: $*"; }
+
+usage() {
+    err
+    err "usage:"
+    err "  $me [options]"
+    err
+    err "options:"
+    err "  --tarball <onload tarball>"
+    err "  --kernel-version <version>"
+    err "  --dtk <image>"
+    err "  --ocp-version <version>"
+    err "  --node-name <name>"
+    err "  --authfile <filepath>"
+    err "  --registry <name>"
+    err "  --debug"
+    err
+    exit 1
+}
+
+function check_image_exists() {
+    local image_name="$1"
+    sudo podman image exists "$image_name"
+    return $?
+}
+
+build_sfc_module() {
+    local dockerfile="sfc-module.Dockerfile"
+    local image_name="$REGHOST/openshift-kmm/sfc-module:$ONLOAD_VERSION-$NODE_KVER"
+    if check_image_exists "$image_name"; then 
+        echo "sfc-module image already exists"
+        return
+    fi
+
+    echo "Building sfc-module image"
+    sudo podman build --authfile="$AUTHFILE" --net=host \
+    --no-cache \
+    --build-arg KERNEL_VERSION="$NODE_KVER" \
+    --build-arg DTK_AUTO="$DTK_IMAGE" \
+    --build-arg ONLOAD_VERSION="$ONLOAD_TARBALL" \
+    -t "$image_name" \
+    -f $dockerfile .
+}
+
+build_onload_module() {
+    local dockerfile="onload-module.Dockerfile"
+    local image_name="$REGHOST/onload-clusterlocal/onload-module:$ONLOAD_VERSION-$NODE_KVER"
+    if check_image_exists "$image_name"; then 
+        echo "onload-module image already exists"
+        return
+    fi
+
+    echo "Building onload-module image"
+    sudo podman build --authfile="$AUTHFILE" --net=host \
+    --no-cache \
+    --build-arg KERNEL_VERSION="$NODE_KVER" \
+    --build-arg DTK_AUTO="$DTK_IMAGE" \
+    --build-arg ONLOAD_VERSION="$ONLOAD_TARBALL" \
+    --build-arg ONLOAD_BUILD_PARAMS="$ONLOAD_BUILD_PARAMS" \
+    -t "$image_name" \
+    -f $dockerfile .
+}
+
+build_onload_userland() {
+    local dockerfile="onload-user.Dockerfile"
+    local image_name="$REGHOST/onload-clusterlocal/onload-user:$ONLOAD_VERSION"
+    if check_image_exists "$image_name"; then 
+        echo "onload-user image already exists"
+        return
+    fi
+
+    echo "Building onload-user image"
+    sudo podman build --authfile="$AUTHFILE" --net=host \
+    --no-cache \
+    --build-arg ONLOAD_VERSION="$ONLOAD_TARBALL" \
+    --build-arg ONLOAD_BUILD_PARAMS="$ONLOAD_BUILD_PARAMS" \
+    -t "$image_name" \
+    -f $dockerfile .
+}
+
+build_onload_device_plugin() {
+    local dockerfile="onload-device-plugin.Dockerfile"
+    local image_name="$REGHOST/onload-clusterlocal/onload-device-plugin:$ONLOAD_VERSION-latest"
+    if check_image_exists "$image_name"; then 
+        echo "onload-device-plugin image already exists"
+        return
+    fi
+
+    local onload_image_name="$REGHOST/onload-clusterlocal/onload-user"
+    local onload_image_tag="$ONLOAD_VERSION"
+    if ! check_image_exists "$onload_image_name:$onload_image_tag"; then
+        echo "onload-user image doesn't exist. Building now"
+        build_onload_userland
+    fi
+
+    echo "Building onload-device-plugin image"
+    sudo podman build --authfile="$AUTHFILE" --net=host \
+    --no-cache \
+    --build-arg ONLOAD_IMAGE="$onload_image_name" \
+    --build-arg IMAGE_TAG="$onload_image_tag" \
+    -t "$image_name" \
+    -f $dockerfile ../onload/deviceplugin
+}
+
+######################################################################
+# main()
+
+OCP_VERSION=""
+DTK_IMAGE=""
+DEFAULT_NODE_NAME="compute-0"
+NODE_KVER=""
+AUTHFILE=""
+REGHOST=""
+ONLOAD_TARBALL=""
+ONLOAD_BUILD_PARAMS=""
+ONLOAD_VERSION=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tarball)        shift; ONLOAD_TARBALL="$1";;
+    --kernel-version) shift; NODE_KVER="$1";;
+    --dtk)            shift; DTK_IMAGE="$1";;
+    --ocp-version)    shift; OCP_VERSION="$1";;
+    --node-name)      shift; DEFAULT_NODE_NAME="$1";;
+    --authfile)       shift; AUTHFILE="$1";;
+    --registry)        shift; REGHOST="$1";;
+    --debug)          ONLOAD_BUILD_PARAMS+=" --debug ";;
+    -*)  usage;;
+    *)   break;;
+  esac
+  shift
+done
+[ $# = 0 ] || usage
+
+if [ -z "$DTK_IMAGE" ]; then
+    if [ -z "$OCP_VERSION" ]; then
+        err "Don't know what ocp version to target"
+        exit 1
+    fi
+    if ! command -v oc &> /dev/null; then
+        err "openshift client could not be found!"
+        err "Cannot determine dtk image -- please specify DTK image to use " 
+        err "with the flag '--dtk'"
+        exit 1
+    fi
+    DTK_IMAGE=$(oc adm release info "$OCP_VERSION" --image-for=driver-toolkit)
+fi
+
+if [ -z "$NODE_KVER" ]; then
+    if ! command -v oc &> /dev/null; then
+        err "openshift client could not be found!"
+        exit 1
+    fi
+    NODE_KVER=$(oc describe node "$DEFAULT_NODE_NAME" | grep 'Kernel Version' | awk '{print $3}')
+fi
+
+if [ -z "$REGHOST" ]; then
+    err "--registry not specified, will attempt to get the internal registry"
+    err "of the cluster with the oc client"
+    if ! command -v oc &> /dev/null; then
+        err "openshift client could not be found!"
+        exit 1
+    fi
+    REGHOST=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
+fi
+
+if [ -z "$ONLOAD_TARBALL" ]; then
+    err "Please specify onload tarball"
+    usage
+fi
+
+ONLOAD_VERSION=$(basename "$ONLOAD_TARBALL" .tgz)
+
+build_sfc_module
+
+build_onload_module
+
+build_onload_userland
+
+build_onload_device_plugin

--- a/scripts/sfc-module.Dockerfile
+++ b/scripts/sfc-module.Dockerfile
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+ARG DTK_AUTO
+FROM ${DTK_AUTO} as builder
+
+ARG KERNEL_VERSION
+
+# This is a bit of a hack using $ONLOAD_VERSION to pass in the filename of the
+# release tarball.
+ARG ONLOAD_VERSION
+
+WORKDIR /build/
+RUN mkdir -p /build/onload
+COPY ${ONLOAD_VERSION} /build
+RUN tar xzf ${ONLOAD_VERSION} -C /build/onload --strip-components=1
+WORKDIR /build/onload/
+
+# Currently there are issues regarding when building the sfc driver due to
+# differences between the DTK image used for building and the ubi image used
+# for loading the drivers.
+#
+# Issues found are with:
+# * vdpa
+# * mtd
+#
+# To prevent building the problematic things we have to pass additional
+# parameters to the driver build. Unfortunately it is currently possible to do
+# this with onload's build scripts, so the driver's Makefile is used directly.
+RUN make -j8 -C src/driver/linux_net CONFIG_SFC_VDPA= CONFIG_SFC_MTD= KVER=${KERNEL_VERSION}
+
+FROM registry.access.redhat.com/ubi8/ubi
+ARG KERNEL_VERSION
+
+RUN yum -y install kmod && yum clean all
+RUN mkdir -p /opt/lib/modules/${KERNEL_VERSION}
+COPY --from=builder /build/onload/src/driver/linux_net/drivers/net/ethernet/sfc/sfc.ko /opt/lib/modules/${KERNEL_VERSION}/
+COPY --from=builder /build/onload/src/driver/linux_net/drivers/net/ethernet/sfc/sfc_driverlink.ko /opt/lib/modules/${KERNEL_VERSION}/
+RUN /usr/sbin/depmod -b /opt ${KERNEL_VERSION}

--- a/sfc/deploy/patch-sfc-module-no-build.yaml
+++ b/sfc/deploy/patch-sfc-module-no-build.yaml
@@ -12,7 +12,7 @@ spec:
         moduleName: sfc
       kernelMappings:
         - regexp: '^.*\.x86_64$'
-          containerImage: image-registry.openshift-image-registry.svc:5000/openshift-kmm/sfc-module:git27b3826-${KERNEL_FULL_VERSION}
+          containerImage: www.example.com/sfc-module:enterpriseonload-8.1.0.2-${KERNEL_FULL_VERSION}
           build:
   selector: # top-level selector
     kubernetes.io/arch: amd64


### PR DESCRIPTION
### [1/2] ON-15022: Add onload_mkimages script
onload_mkimages.sh takes as input a filepath to a tarball release of
onload as well as some information about the cluster to build for
(OpenShift version, node kernel version) and produces a set of images
from the onload release that should work in the described cluster.

A new set of Dockerfile is also included in the scripts/ directory which
are used by onload_mkimages because the existing Dockerfiles are built
to pull from github, not work with local files.

### [2/2] ON-14945: Pull pre-built images from example external registry

Update the images registry mentioned in the deploy kustomization files
for onload and sfc to use `www.example.com` as the source for the images.

## Testing done
Used the `onload_mkimages.sh` script to build images on a DUT (outside of
cluster) and then pushed to a local image registry, then updated the
kustomization files to pull the images from the registry.
Deploy everything in the cluster and ran onload with accelerated traffic.