### PR TITLE
ON-14945: Add kustomization to configure source locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Expected environment:
   - Node Feature Discovery (NFD) Operator
   - Kernel Module Management (KMM) Operator ([Redhat docs](https://docs.openshift.com/container-platform/4.12/hardware_enablement/kmm-kernel-module-management.html), [codebase docs](https://kmm.sigs.k8s.io/documentation/deploy_kmod/))
 
+#### Build sources
+
+When following the build steps below to build from source in a cluster, ensure
+the source location paths are correct for your environment. The default source
+location paths are [onload](https://github.com/Xilinx-CNS/onload) and this
+repository. This behaviour can be changed by editing
+[onload-sources.conf](base/onload-sources.conf).
+
+The format of the source files must be `*.tar.gz` as the following steps access
+and download them using `ADD` commands in Dockerfiles.
+
 ### SFC out-of-tree driver
 
 This section may be skipped without affecting the other deployment steps, however, the out-of-tree `sfc` driver is currently required when using the provided `onload` driver with a Solarflare card.

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -1,0 +1,4 @@
+configMapGenerator:
+- name: onload-sources-configmap
+  envs:
+  - onload-sources.conf

--- a/base/onload-sources.conf
+++ b/base/onload-sources.conf
@@ -1,0 +1,2 @@
+ONLOAD_LOCATION=https://github.com/Xilinx-CNS/onload/archive/refs/tags/v8.1.0.tar.gz
+KUBERNETES_ONLOAD_LOCATION=https://github.com/Xilinx-CNS/kubernetes-onload/archive/refs/tags/v3.0.0-pre1.tar.gz

--- a/onload/base/kustomization.yaml
+++ b/onload/base/kustomization.yaml
@@ -8,3 +8,31 @@ resources:
 - ../kmm/
 - ../cplane/
 - ../deviceplugin/
+- ../../base
+
+replacements:
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.ONLOAD_LOCATION
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-user
+    fieldPaths:
+    - spec.strategy.dockerStrategy.buildArgs.[name=ONLOAD_LOCATION].value
+  - select:
+      kind: Module
+      name: onload-module
+    fieldPaths:
+    - spec.moduleLoader.container.kernelMappings.0.build.buildArgs.[name=ONLOAD_LOCATION].value
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.KUBERNETES_ONLOAD_LOCATION
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-device-plugin
+    fieldPaths:
+    - spec.strategy.dockerStrategy.buildArgs.[name=KUBERNETES_ONLOAD_LOCATION].value

--- a/onload/build/deviceplugin/0000-buildconfig.yaml
+++ b/onload/build/deviceplugin/0000-buildconfig.yaml
@@ -20,10 +20,11 @@ spec:
           namespace: onload-clusterlocal
   source:
     dockerfile: (placeholder)
-
   strategy:
     dockerStrategy:
       buildArgs:
+      - name: KUBERNETES_ONLOAD_LOCATION
+        value: (placeholder)
   output:
     to:
       kind: ImageStreamTag

--- a/onload/build/deviceplugin/Dockerfile
+++ b/onload/build/deviceplugin/Dockerfile
@@ -2,8 +2,12 @@
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 FROM golang:1.20.4 AS builder
 
+ARG KUBERNETES_ONLOAD_LOCATION
+
 WORKDIR /app
-RUN git clone --depth 1 https://github.com/Xilinx-CNS/kubernetes-onload.git
+ADD ${KUBERNETES_ONLOAD_LOCATION} kubernetes-onload.tar.gz
+RUN mkdir -p /app/kubernetes-onload
+RUN tar xzf kubernetes-onload.tar.gz -C /app/kubernetes-onload --strip-components=1
 
 WORKDIR /app/kubernetes-onload/onload/deviceplugin
 RUN go build -o /app/onload-plugin

--- a/onload/build/userbuild/Dockerfile
+++ b/onload/build/userbuild/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 FROM registry.redhat.io/ubi8/ubi-minimal as builder
 ARG ONLOAD_BUILD_PARAMS
-ARG ONLOAD_VERSION
+ARG ONLOAD_LOCATION
 
 # Install requirements for building onload userland
 RUN microdnf install -y binutils \
@@ -38,7 +38,7 @@ RUN rpm -i libcap-*.src.rpm \
 # END
 
 # Build onload userland components
-ADD https://github.com/Xilinx-CNS/onload/archive/${ONLOAD_VERSION}.tar.gz onload.tar.gz
+ADD ${ONLOAD_LOCATION} onload.tar.gz
 RUN mkdir -p /build/onload
 RUN tar xzf onload.tar.gz -C /build/onload --strip-components=1
 WORKDIR /build/onload/

--- a/onload/build/userbuild/buildconfig.yaml
+++ b/onload/build/userbuild/buildconfig.yaml
@@ -20,8 +20,8 @@ spec:
       buildArgs:
       - name: ONLOAD_BUILD_PARAMS
         value:
-      - name: ONLOAD_VERSION
-        value: v8.1.0
+      - name: ONLOAD_LOCATION
+        value: (placeholder)
   output:
     to:
       kind: ImageStreamTag

--- a/onload/kmm/Dockerfile
+++ b/onload/kmm/Dockerfile
@@ -4,11 +4,11 @@ ARG DTK_AUTO
 
 FROM ${DTK_AUTO} as builder
 ARG ONLOAD_BUILD_PARAMS
-ARG ONLOAD_VERSION
+ARG ONLOAD_LOCATION
 ARG KERNEL_VERSION
 
 WORKDIR /build/
-ADD https://github.com/Xilinx-CNS/onload/archive/${ONLOAD_VERSION}.tar.gz onload.tar.gz
+ADD ${ONLOAD_LOCATION} onload.tar.gz
 RUN mkdir -p /build/onload
 RUN tar xzf onload.tar.gz -C /build/onload --strip-components=1
 WORKDIR /build/onload/

--- a/onload/kmm/onload-module.yaml
+++ b/onload/kmm/onload-module.yaml
@@ -52,7 +52,7 @@ spec:
             buildArgs:
             - name: ONLOAD_BUILD_PARAMS
               value: ""
-            - name: ONLOAD_VERSION
-              value: v8.1.0
+            - name: ONLOAD_LOCATION
+              value: (placeholder)
   selector: # top-level selector
     kubernetes.io/arch: amd64

--- a/sfc/kmm/Dockerfile
+++ b/sfc/kmm/Dockerfile
@@ -4,11 +4,11 @@ ARG DTK_AUTO
 FROM ${DTK_AUTO} as builder
 
 ARG KERNEL_VERSION
-ARG ONLOAD_VERSION
+ARG ONLOAD_LOCATION
 
 WORKDIR /build/
 
-ADD https://github.com/Xilinx-CNS/onload/archive/${ONLOAD_VERSION}.tar.gz onload.tar.gz
+ADD ${ONLOAD_LOCATION} onload.tar.gz
 RUN mkdir -p /build/onload
 RUN tar xzf onload.tar.gz -C /build/onload --strip-components=1
 WORKDIR /build/onload/

--- a/sfc/kmm/kustomization.yaml
+++ b/sfc/kmm/kustomization.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - sfc-module.yaml
+- ../../base
+
 namespace: openshift-kmm
 configMapGenerator:
 - name: sfc-module-dockerfile
@@ -11,3 +13,15 @@ configMapGenerator:
   - dockerfile=Dockerfile
 configurations:
 - module-nameref.yaml
+
+replacements:
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.ONLOAD_LOCATION
+  targets:
+  - select:
+      kind: Module
+      name: sfc-module
+    fieldPaths:
+    - spec.moduleLoader.container.kernelMappings.0.build.buildArgs.[name=ONLOAD_LOCATION].value

--- a/sfc/kmm/sfc-module.yaml
+++ b/sfc/kmm/sfc-module.yaml
@@ -17,7 +17,7 @@ spec:
             dockerfileConfigMap:
               name: sfc-module-dockerfile
             buildArgs:
-            - name: ONLOAD_VERSION
-              value: v8.1.0
+            - name: ONLOAD_LOCATION
+              value: (placeholder)
   selector: # top-level selector
     kubernetes.io/arch: amd64


### PR DESCRIPTION
Adds a cluster/ directory with an onload-sources.conf file which specificies the locations of tarballs for the Dockerfiles to pull and build from. This defaults to using github as the source, but this change will allow for easy configuration if github is inaccesible.

Also adds kustomization replacements to update the buildArgs for the onload and sfc builds. Existing command line invocations should be unaffected by this change.

## Testing done
Works in cluster, also tested with a local http server which provided the onload tarball