### PR TITLE
ON-15024: Add Onload diagnostics container

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,22 @@ $ oc get image | grep onload
 ```
 Remove any outstanding manually with `oc delete image`. (Not providing any automated invocation to prevent removal of the false-positive images.)
 
+## Troubleshooting
+
+Onload comes with a troubleshooting container with pre-installed utilities like `onload_stackdump`. Create a privileged debugging container to use these utilities interactively:
+
+```console
+$ oc debug --image-stream=onload-clusterlocal/onload-diagnostics:v8.1.0 node/compute-0
+Temporary namespace openshift-debug-d2ss2 is created for debugging node...
+Starting pod/compute-0-debug ...
+To use host binaries, run `chroot /host`
+Pod IP: 192.168.128.6
+If you don't see a command prompt, try pressing enter.
+sh-4.4# onload_stackdump
+#stack-id stack-name      pids
+0         -               4159878
+```
+
 ## Deploying artifacts into an airgapped cluster
 
 ### Images required

--- a/onload/build/diagnostics/ContainerFileNotice
+++ b/onload/build/diagnostics/ContainerFileNotice
@@ -1,0 +1,47 @@
+NOTICE - BY INVOKING THIS SCRIPT AND USING THE SOFTWARE INSTALLED BY THE
+SCRIPT, YOU AGREE ON BEHALF OF YOURSELF AND YOUR EMPLOYER (IF APPLICABLE) TO BE
+BOUND TO THE LICENSE AGREEMENTS APPLICABLE TO THE PACKAGES IDENTIFIED BELOW
+THAT YOU INSTALL BY RUNNING THE SCRIPT. YOU UNDERSTAND THAT THE INSTALLATION OF
+THE PACKAGES LISTED BELOW MAY ALSO RESULT IN THE INSTALLATION ON YOUR SYSTEM OF
+ADDITIONAL PACKAGES NOT LISTED BELOW IN ORDER TO OPERATE (EACH, A
+‘DEPENDENCY’). ADVANCED MICRO DEVICES, INC., ON BEHALF OF ITSELF AND ITS
+SUBSIDIARIES AND AFFILIATES, DOES NOT GRANT TO YOU ANY RIGHTS OR LICENSES TO
+ANY SUCH DEPENDENCY. THE SCRIPT ITSELF IS LICENSED TO YOU SUBJECT TO THE
+FOLLOWING TERMS:
+
+Copyright © 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+
+This file is licensed under the following license terms (MIT):
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+This file pulls in the following packages subject to the licenses identified
+below:
+
+| Package, Version                 | License      | URL                                                                                    |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|
+| Red Hat Universal Basic Image, 8 | UBI EULA     | https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf |
+|                                  | + Various    |                                                                                        |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|
+| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/master/src/onload/distfiles/LICENSE          |
+|                                  | AND          |                                                                                        |
+|                                  | BSD-2-Clause |                                                                                        |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|
+| tcpdump, 4.9                     | BSD-3-Clause | https://github.com/the-tcpdump-group/tcpdump/blob/master/LICENSE                       |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/onload/build/diagnostics/Dockerfile
+++ b/onload/build/diagnostics/Dockerfile
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+FROM image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-user:v8.1.0 AS onload-user
+
+FROM ubi8
+
+RUN dnf install -y libpcap procps-ng util-linux iptables python3
+
+# Best effort to install tcpdump for onload_tcpdump.
+RUN curl http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/tcpdump-4.9.3-3.el8.x86_64.rpm -o tcpdump-4.9.3-3.el8.x86_64.rpm
+RUN rpm -i tcpdump-4.9.3-3.el8.x86_64.rpm || exit 0
+
+COPY --from=onload-user /opt/onload/usr/bin/ /usr/bin/

--- a/onload/build/diagnostics/buildconfig.yaml
+++ b/onload/build/diagnostics/buildconfig.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: onload-diagnostics
+  name: onload-diagnostics
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  runPolicy: Serial
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChange:
+        from:
+          kind: ImageStreamTag
+          name: onload-user:v8.1.0
+          namespace: onload-clusterlocal
+  source:
+    dockerfile: (placeholder)
+
+  strategy:
+    dockerStrategy:
+      buildArgs:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: onload-diagnostics:v8.1.0
+      namespace: onload-clusterlocal

--- a/onload/build/diagnostics/kustomization.yaml
+++ b/onload/build/diagnostics/kustomization.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- buildconfig.yaml
+
+configMapGenerator:
+- name: onload-diagnostics-dockerfile
+  files:
+  - dockerfile=Dockerfile
+
+replacements:
+- source:
+    kind: ConfigMap
+    name: onload-diagnostics-dockerfile
+    fieldPath: data.dockerfile
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-diagnostics
+    fieldPaths:
+    - spec.source.dockerfile

--- a/onload/build/kustomization.yaml
+++ b/onload/build/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deviceplugin/
+- diagnostics/
 - userbuild/

--- a/onload/imagestream/imagestream.yaml
+++ b/onload/imagestream/imagestream.yaml
@@ -39,3 +39,10 @@ metadata:
   name: onload-module
   namespace: onload-clusterlocal
 spec: {}
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: onload-diagnostics
+  namespace: onload-clusterlocal
+spec: {}


### PR DESCRIPTION
Package Onload troubleshooting utilities in the new "onload-debug" image. Containers based on that image must be privileged to access devfs files in the nodes needed for "onload_stackdump" and others to gather data.