### PR TITLE
ON-14945: Add sfnettest and sfptpd to onload-sources.conf

### DIFF
--- a/base/onload-sources.conf
+++ b/base/onload-sources.conf
@@ -2,3 +2,4 @@
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 ONLOAD_LOCATION=https://github.com/Xilinx-CNS/onload/archive/refs/tags/v8.1.0.tar.gz
 KUBERNETES_ONLOAD_LOCATION=https://github.com/Xilinx-CNS/kubernetes-onload/archive/refs/heads/master.tar.gz
+SFNETTEST_LOCATION=https://github.com/Xilinx-CNS/cns-sfnettest/archive/refs/tags/sfnettest-1.6.0-rc1.tar.gz

--- a/base/onload-sources.conf
+++ b/base/onload-sources.conf
@@ -3,3 +3,4 @@
 ONLOAD_LOCATION=https://github.com/Xilinx-CNS/onload/archive/refs/tags/v8.1.0.tar.gz
 KUBERNETES_ONLOAD_LOCATION=https://github.com/Xilinx-CNS/kubernetes-onload/archive/refs/heads/master.tar.gz
 SFNETTEST_LOCATION=https://github.com/Xilinx-CNS/cns-sfnettest/archive/refs/tags/sfnettest-1.6.0-rc1.tar.gz
+SFPTPD_LOCATION=https://github.com/Xilinx-CNS/sfptpd/archive/ab881b3650c642f4dc8142c9b5052da3e6046cdf.tar.gz

--- a/examples/sfnettest/ContainerFileNotice
+++ b/examples/sfnettest/ContainerFileNotice
@@ -39,5 +39,5 @@ below:
 | Red Hat Universal Basic Image, 8 | UBI EULA     | https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf |
 |                                  | + Various    |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|
-| AMD sfnettest, 1.5               | GPL-2.0-only | https://github.com/Xilinx-CNS/cns-sfnettest/blob/master/LICENSE                        |
+| AMD sfnettest, 1.6.0-rc1         | GPL-2.0-only | https://github.com/Xilinx-CNS/cns-sfnettest/blob/sfnettest-1.6.0-rc1/LICENSE           |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/examples/sfnettest/build/kustomization.yaml
+++ b/examples/sfnettest/build/kustomization.yaml
@@ -4,3 +4,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - sfnettest-build.yaml
+- ../../../base
+
+replacements:
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.SFNETTEST_LOCATION
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-sfnettest
+    fieldPaths:
+    - spec.strategy.dockerStrategy.buildArgs.[name=SFNETTEST_LOCATION].value

--- a/examples/sfnettest/build/sfnettest-build.yaml
+++ b/examples/sfnettest/build/sfnettest-build.yaml
@@ -22,13 +22,13 @@ spec:
   source:
     dockerfile: |
       FROM registry.redhat.io/ubi8/ubi-init
-      ARG SFNETTEST_VERSION
+      ARG SFNETTEST_LOCATION
 
       RUN dnf install -y git make findutils gcc  # CNS-sfnettest build time
       RUN dnf install -y pciutils                # (Optional) sfnt-pingpong runtime
 
       WORKDIR /build/
-      ADD https://github.com/Xilinx-CNS/cns-sfnettest/archive/refs/tags/${SFNETTEST_VERSION}.tar.gz cns-sfnettest.tar.gz
+      ADD ${SFNETTEST_LOCATION} cns-sfnettest.tar.gz
       RUN mkdir -p /build/cns-sfnettest
       RUN tar xzf cns-sfnettest.tar.gz -C /build/cns-sfnettest --strip-components=1
 
@@ -40,8 +40,8 @@ spec:
   strategy:
     dockerStrategy:
       buildArgs:
-      - name: SFNETTEST_VERSION
-        value: "sfnettest-1.6.0-rc1"
+      - name: SFNETTEST_LOCATION
+        value: (placeholder)
   output:
     to:
       kind: ImageStreamTag

--- a/onload/build/deviceplugin/ContainerFileNotice
+++ b/onload/build/deviceplugin/ContainerFileNotice
@@ -39,7 +39,7 @@ below:
 | Red Hat Universal Basic Image, 8                               | UBI EULA     | https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf         |
 |                                                                | + Various    |                                                                                                |
 |----------------------------------------------------------------+--------------+------------------------------------------------------------------------------------------------|
-| AMD Onload, 8.1                                                | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/master/src/onload/distfiles/LICENSE                  |
+| AMD Onload, 8.1                                                | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/v8.1.0/src/onload/distfiles/LICENSE                  |
 |                                                                | AND          |                                                                                                |
 |                                                                | BSD-2-Clause |                                                                                                |
 |----------------------------------------------------------------+--------------+------------------------------------------------------------------------------------------------|

--- a/onload/build/diagnostics/ContainerFileNotice
+++ b/onload/build/diagnostics/ContainerFileNotice
@@ -39,7 +39,7 @@ below:
 | Red Hat Universal Basic Image, 8 | UBI EULA     | https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf |
 |                                  | + Various    |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|
-| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/master/src/onload/distfiles/LICENSE          |
+| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/v8.1.0/src/onload/distfiles/LICENSE          |
 |                                  | AND          |                                                                                        |
 |                                  | BSD-2-Clause |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/onload/build/userbuild/ContainerFileNotice
+++ b/onload/build/userbuild/ContainerFileNotice
@@ -39,7 +39,7 @@ below:
 | Red Hat Universal Basic Image, 8 | UBI EULA     | https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf |
 |                                  | + Various    |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|
-| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/master/src/onload/distfiles/LICENSE          |
+| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/v8.1.0/src/onload/distfiles/LICENSE          |
 |                                  | AND          |                                                                                        |
 |                                  | BSD-2-Clause |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/onload/cplane/ContainerFileNotice
+++ b/onload/cplane/ContainerFileNotice
@@ -39,7 +39,7 @@ below:
 | Red Hat Universal Basic Image, 8 | UBI EULA     | https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf |
 |                                  | + Various    |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|
-| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/master/src/onload/distfiles/LICENSE          |
+| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/v8.1.0/src/onload/distfiles/LICENSE          |
 |                                  | AND          |                                                                                        |
 |                                  | BSD-2-Clause |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/onload/kmm/ContainerFileNotice
+++ b/onload/kmm/ContainerFileNotice
@@ -39,7 +39,7 @@ below:
 | Red Hat Universal Basic Image, 8 | UBI EULA     | https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf |
 |                                  | + Various    |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|
-| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/master/src/onload/distfiles/LICENSE          |
+| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/v8.1.0/src/onload/distfiles/LICENSE          |
 |                                  | AND          |                                                                                        |
 |                                  | BSD-2-Clause |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/sfc/kmm/ContainerFileNotice
+++ b/sfc/kmm/ContainerFileNotice
@@ -39,7 +39,7 @@ below:
 | Red Hat Universal Basic Image, 8 | UBI EULA     | https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf |
 |                                  | + Various    |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|
-| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/master/src/onload/distfiles/LICENSE          |
+| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/v8.1.0/src/onload/distfiles/LICENSE          |
 |                                  | AND          |                                                                                        |
 |                                  | BSD-2-Clause |                                                                                        |
 |----------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/sfptpd/build/kustomization.yaml
+++ b/sfptpd/build/kustomization.yaml
@@ -4,3 +4,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - sfptpd-build.yaml
+- ../../base
+
+replacements:
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.SFPTPD_LOCATION
+  targets:
+  - select:
+      kind: BuildConfig
+      name: sfptpd-builder
+    fieldPaths:
+    - spec.strategy.dockerStrategy.buildArgs.[name=SFPTPD_LOCATION].value

--- a/sfptpd/build/sfptpd-build.yaml
+++ b/sfptpd/build/sfptpd-build.yaml
@@ -31,8 +31,8 @@ spec:
   strategy:
     dockerStrategy:
       buildArgs:
-      - name: SFPTPD_VERSION
-        value: ab881b3650c642f4dc8142c9b5052da3e6046cdf
+      - name: SFPTPD_LOCATION
+        value: (placeholder)
   output:
     to:
       kind: ImageStreamTag
@@ -43,8 +43,8 @@ spec:
       WORKDIR src
       RUN microdnf -y install make gcc tar bzip2 redhat-rpm-config
       RUN microdnf -y --enablerepo=ubi-9-baseos-source download --source libmnl libcap
-      ARG SFPTPD_VERSION=master
-      ADD https://github.com/Xilinx-CNS/sfptpd/archive/${SFPTPD_VERSION}.tar.gz sfptpd.tar.gz
+      ARG SFPTPD_LOCATION
+      ADD ${SFPTPD_LOCATION} sfptpd.tar.gz
 
       RUN mkdir libcap libmnl sfptpd
       RUN rpm -i libcap-*.src.rpm \


### PR DESCRIPTION
Currently only `onload` and `kubernetes-onload` are included in `onload-sources.conf`, this change updates the file to include definitions for the locations of `sfptpd` and `sfnettest`.

## Testing done
End-to-end test in cluster. Everything builds and runs (including sfptpd)