### PR TITLE
cleanup: Pinpoint deviceplugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,23 @@ For Onload & SFC:
 The `DTK_AUTO` image is determined by the KMM Operator depending on the kernel
 versions of the nodes in your cluster. To get the location of this image you
 can run:
+
 ```console
 $ oc adm release info $OCP_VERSION --image-for=driver-toolkit
 ```
-Where `$OCP_VERSION` is the version of the Openshift cluster on which you will
+Where `$OCP_VERSION` is the version of the OpenShift cluster on which you will
 deploy Onload.
 
 
-For Sfptpd:
+For sfptpd:
 * ubi9-minimal:9.2
 
-For Sfnettest example pod:
+For sfnettest example pod:
 * ubi8-init:8.8
+
+The following images are all available from `registry.access.redhat.com`,
+`registry.redhat.io`, or `docker.io`, so will typically be available on RHEL
+hosts with `docker pull <image>` and OCP Internet-connected clusters.
 
 #### Build sources
 


### PR DESCRIPTION
Using a fixed hash instead of the "master" branch potentially prevents breakages in dev. branches if there is a device plugin change in the "master" branch incompatible with the older version of the device plugin still in use in dev. branches.