### PR TITLE
ON-14945: Make base image locations customisable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ repository. This behaviour can be changed by editing
 The format of the source files must be `*.tar.gz` as the following steps access
 and download them using `ADD` commands in Dockerfiles.
 
+#### Base Images
+
+The following are the base images used for in-cluster builds:
+
+* ubi8
+* ubi8-minimal
+* ubi8-init
+* ubi9-minimal
+* golang:1.20.4
+* `DTK_AUTO` with the value provided by the KMM operator.
+
+By default these images will be pulled from internet registries (quay.io,
+docker.io, registry.access.redhat.com). If you wish to configure the locations
+of these images, then they can be changed by editing [onload-sources.conf](base/onload-sources.conf).
+
 ### SFC out-of-tree driver
 
 This section may be skipped without affecting the other deployment steps, however, the out-of-tree `sfc` driver is currently required when using the provided `onload` driver with a Solarflare card.

--- a/base/onload-sources.conf
+++ b/base/onload-sources.conf
@@ -1,6 +1,22 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+# Source code locations for in-cluster builds
 ONLOAD_LOCATION=https://github.com/Xilinx-CNS/onload/archive/refs/tags/v8.1.0.tar.gz
 KUBERNETES_ONLOAD_LOCATION=https://github.com/Xilinx-CNS/kubernetes-onload/archive/refs/heads/master.tar.gz
 SFNETTEST_LOCATION=https://github.com/Xilinx-CNS/cns-sfnettest/archive/refs/tags/sfnettest-1.6.0-rc1.tar.gz
 SFPTPD_LOCATION=https://github.com/Xilinx-CNS/sfptpd/archive/ab881b3650c642f4dc8142c9b5052da3e6046cdf.tar.gz
+
+# Customisable image locations:
+UBI8_IMAGE=registry.access.redhat.com/ubi8
+UBI8_MINIMAL_IMAGE=registry.access.redhat.com/ubi8-minimal
+UBI8_INIT_IMAGE=registry.access.redhat.com/ubi8-init
+
+UBI9_MINIMAL_IMAGE=registry.access.redhat.com/ubi9-minimal
+
+GOLANG_IMAGE=docker.io/library/golang:1.20.4
+
+# DTK_IMAGE, if non-empty, is used to explicitly choose the image used to build
+# kernel modules. If left empty then it will use the DTK_AUTO image will the
+# value provided by the KMM operator.
+DTK_IMAGE=

--- a/examples/sfnettest/build/kustomization.yaml
+++ b/examples/sfnettest/build/kustomization.yaml
@@ -17,3 +17,13 @@ replacements:
       name: onload-sfnettest
     fieldPaths:
     - spec.strategy.dockerStrategy.buildArgs.[name=SFNETTEST_LOCATION].value
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.UBI8_INIT_IMAGE
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-sfnettest
+    fieldPaths:
+    - spec.strategy.dockerStrategy.buildArgs.[name=UBI8_INIT_IMAGE].value

--- a/examples/sfnettest/build/sfnettest-build.yaml
+++ b/examples/sfnettest/build/sfnettest-build.yaml
@@ -21,7 +21,8 @@ spec:
     - type: "ImageChange"
   source:
     dockerfile: |
-      FROM registry.redhat.io/ubi8/ubi-init
+      ARG UBI8_INIT_IMAGE
+      FROM ${UBI8_INIT_IMAGE}
       ARG SFNETTEST_LOCATION
 
       RUN dnf install -y git make findutils gcc  # CNS-sfnettest build time
@@ -41,6 +42,8 @@ spec:
     dockerStrategy:
       buildArgs:
       - name: SFNETTEST_LOCATION
+        value: (placeholder)
+      - name: UBI8_INIT_IMAGE
         value: (placeholder)
   output:
     to:

--- a/onload/base/kustomization.yaml
+++ b/onload/base/kustomization.yaml
@@ -36,3 +36,52 @@ replacements:
       name: onload-device-plugin
     fieldPaths:
     - spec.strategy.dockerStrategy.buildArgs.[name=KUBERNETES_ONLOAD_LOCATION].value
+
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.UBI8_MINIMAL_IMAGE
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-user
+    fieldPaths:
+    - spec.strategy.dockerStrategy.buildArgs.[name=UBI8_MINIMAL_IMAGE].value
+
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.UBI8_IMAGE
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-diagnostics
+    fieldPaths:
+    - spec.strategy.dockerStrategy.buildArgs.[name=UBI8_IMAGE].value
+  - select:
+      kind: Module
+      name: onload-module
+    fieldPaths:
+    - spec.moduleLoader.container.kernelMappings.0.build.buildArgs.[name=UBI8_IMAGE].value
+
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.GOLANG_IMAGE
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-device-plugin
+    fieldPaths:
+    - spec.strategy.dockerStrategy.buildArgs.[name=GOLANG_IMAGE].value
+
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.DTK_IMAGE
+  targets:
+  - select:
+      kind: Module
+      name: onload-module
+    fieldPaths:
+    - spec.moduleLoader.container.kernelMappings.0.build.buildArgs.[name=DTK_IMAGE].value

--- a/onload/build/deviceplugin/0000-buildconfig.yaml
+++ b/onload/build/deviceplugin/0000-buildconfig.yaml
@@ -25,6 +25,8 @@ spec:
       buildArgs:
       - name: KUBERNETES_ONLOAD_LOCATION
         value: (placeholder)
+      - name: GOLANG_IMAGE
+        value: (placeholder)
   output:
     to:
       kind: ImageStreamTag

--- a/onload/build/deviceplugin/Dockerfile
+++ b/onload/build/deviceplugin/Dockerfile
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
-FROM golang:1.20.4 AS builder
+ARG GOLANG_IMAGE
+
+FROM ${GOLANG_IMAGE} AS builder
 
 ARG KUBERNETES_ONLOAD_LOCATION
 

--- a/onload/build/diagnostics/Dockerfile
+++ b/onload/build/diagnostics/Dockerfile
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+ARG UBI8_IMAGE
+
 FROM image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-user:v8.1.0 AS onload-user
 
-FROM ubi8
+FROM ${UBI8_IMAGE}
 
 RUN dnf install -y libpcap procps-ng util-linux iptables python3
 

--- a/onload/build/diagnostics/buildconfig.yaml
+++ b/onload/build/diagnostics/buildconfig.yaml
@@ -24,6 +24,8 @@ spec:
   strategy:
     dockerStrategy:
       buildArgs:
+      - name: UBI8_IMAGE
+        value: (placeholder)
   output:
     to:
       kind: ImageStreamTag

--- a/onload/build/userbuild/Dockerfile
+++ b/onload/build/userbuild/Dockerfile
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
-FROM registry.redhat.io/ubi8/ubi-minimal as builder
+ARG UBI8_MINIMAL_IMAGE
+
+FROM ${UBI8_MINIMAL_IMAGE} as builder
 ARG ONLOAD_BUILD_PARAMS
 ARG ONLOAD_LOCATION
 
@@ -50,7 +52,7 @@ ENV i_prefix=/opt/onload
 RUN scripts/onload_install --nobuild --userfiles
 
 # Prepare a minimal image with onload userland
-FROM registry.redhat.io/ubi8/ubi-minimal
+FROM ${UBI8_MINIMAL_IMAGE}
 
 COPY --from=builder /opt/onload /opt/onload
 

--- a/onload/build/userbuild/buildconfig.yaml
+++ b/onload/build/userbuild/buildconfig.yaml
@@ -22,6 +22,8 @@ spec:
         value:
       - name: ONLOAD_LOCATION
         value: (placeholder)
+      - name: UBI8_MINIMAL_IMAGE
+        value: (placeholder)
   output:
     to:
       kind: ImageStreamTag

--- a/onload/kmm/Dockerfile
+++ b/onload/kmm/Dockerfile
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 ARG DTK_AUTO
+ARG DTK_IMAGE
+ARG UBI8_IMAGE
 
-FROM ${DTK_AUTO} as builder
+FROM ${DTK_IMAGE:-${DTK_AUTO}} as builder
 ARG ONLOAD_BUILD_PARAMS
 ARG ONLOAD_LOCATION
 ARG KERNEL_VERSION
@@ -16,7 +18,7 @@ WORKDIR /build/onload/
 RUN scripts/onload_build --kernel --kernelver ${KERNEL_VERSION} ${ONLOAD_BUILD_PARAMS}
 RUN scripts/onload_install --nobuild --kernelfiles --kernelver ${KERNEL_VERSION}
 
-FROM docker.io/redhat/ubi8:latest
+FROM ${UBI8_IMAGE}
 ARG KERNEL_VERSION
 
 RUN yum -y install kmod && yum clean all

--- a/onload/kmm/onload-module.yaml
+++ b/onload/kmm/onload-module.yaml
@@ -54,5 +54,9 @@ spec:
               value: ""
             - name: ONLOAD_LOCATION
               value: (placeholder)
+            - name: DTK_IMAGE
+              value: (placeholder)
+            - name: UBI8_IMAGE
+              value: (placeholder)
   selector: # top-level selector
     kubernetes.io/arch: amd64

--- a/sfc/kmm/Dockerfile
+++ b/sfc/kmm/Dockerfile
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 ARG DTK_AUTO
-FROM ${DTK_AUTO} as builder
+ARG DTK_IMAGE
+ARG UBI8_IMAGE
+
+FROM ${DTK_IMAGE:-${DTK_AUTO}} as builder
 
 ARG KERNEL_VERSION
 ARG ONLOAD_LOCATION
@@ -26,7 +29,7 @@ WORKDIR /build/onload/
 # this with onload's build scripts, so the driver's Makefile is used directly.
 RUN make -j8 -C src/driver/linux_net CONFIG_SFC_VDPA= CONFIG_SFC_MTD= KVER=${KERNEL_VERSION}
 
-FROM docker.io/redhat/ubi8:latest
+FROM ${UBI8_IMAGE}
 ARG KERNEL_VERSION
 
 RUN yum -y install kmod && yum clean all

--- a/sfc/kmm/kustomization.yaml
+++ b/sfc/kmm/kustomization.yaml
@@ -25,3 +25,23 @@ replacements:
       name: sfc-module
     fieldPaths:
     - spec.moduleLoader.container.kernelMappings.0.build.buildArgs.[name=ONLOAD_LOCATION].value
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.UBI8_IMAGE
+  targets:
+  - select:
+      kind: Module
+      name: sfc-module
+    fieldPaths:
+    - spec.moduleLoader.container.kernelMappings.0.build.buildArgs.[name=UBI8_IMAGE].value
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.DTK_IMAGE
+  targets:
+  - select:
+      kind: Module
+      name: sfc-module
+    fieldPaths:
+    - spec.moduleLoader.container.kernelMappings.0.build.buildArgs.[name=DTK_IMAGE].value

--- a/sfc/kmm/sfc-module.yaml
+++ b/sfc/kmm/sfc-module.yaml
@@ -19,5 +19,9 @@ spec:
             buildArgs:
             - name: ONLOAD_LOCATION
               value: (placeholder)
+            - name: DTK_IMAGE
+              value: (placeholder)
+            - name: UBI8_IMAGE
+              value: (placeholder)
   selector: # top-level selector
     kubernetes.io/arch: amd64

--- a/sfptpd/build/kustomization.yaml
+++ b/sfptpd/build/kustomization.yaml
@@ -17,3 +17,13 @@ replacements:
       name: sfptpd-builder
     fieldPaths:
     - spec.strategy.dockerStrategy.buildArgs.[name=SFPTPD_LOCATION].value
+- source:
+    kind: ConfigMap
+    name: onload-sources-configmap
+    fieldPath: data.UBI9_MINIMAL_IMAGE
+  targets:
+  - select:
+      kind: BuildConfig
+      name: sfptpd-builder
+    fieldPaths:
+    - spec.strategy.dockerStrategy.buildArgs.[name=UBI9_MINIMAL_IMAGE].value

--- a/sfptpd/build/sfptpd-build.yaml
+++ b/sfptpd/build/sfptpd-build.yaml
@@ -33,13 +33,16 @@ spec:
       buildArgs:
       - name: SFPTPD_LOCATION
         value: (placeholder)
+      - name: UBI9_MINIMAL_IMAGE
+        value: (placeholder)
   output:
     to:
       kind: ImageStreamTag
       name: sfptpd:git-ab881b3
   source:
     dockerfile: |
-      FROM registry.access.redhat.com/ubi9/ubi-minimal AS build
+      ARG UBI9_MINIMAL_IMAGE
+      FROM ${UBI9_MINIMAL_IMAGE} AS build
       WORKDIR src
       RUN microdnf -y install make gcc tar bzip2 redhat-rpm-config
       RUN microdnf -y --enablerepo=ubi-9-baseos-source download --source libmnl libcap
@@ -64,7 +67,7 @@ spec:
        INST_INITS="" \
        make -C sfptpd -j 10 install
 
-      FROM registry.access.redhat.com/ubi9/ubi-minimal AS runtime
+      FROM ${UBI9_MINIMAL_IMAGE} AS runtime
       RUN microdnf -y install libmnl
       COPY --from=build /staged /
       WORKDIR /var/lib/sfptpd


### PR DESCRIPTION
This change adds a set of new variables to onload-sources.conf which allows users to customise the location of base images needed to build the set of onload images.

Default values are set to use internet registries.

## Testing done
Everything builds in-cluster (using default values) and accelerated traffic passes.