### PR TITLE
ON-15040: Add onload-must-gather image for log collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ hosts with `docker pull <image>` and OCP Internet-connected clusters.
 For Onload & SFC:
 * ubi8:8.8
 * ubi8-minimal:8.8
+* openshift4/ose-cli:v4.12.0
 * golang:1.20.4
 * `DTK_AUTO`
 
@@ -240,7 +241,11 @@ Remove any outstanding manually with `oc delete image`. (Not providing any autom
 
 ## Troubleshooting
 
-Onload comes with a troubleshooting container with pre-installed utilities like `onload_stackdump`. Create a privileged debugging container to use these utilities interactively:
+The Onload Diagnostics container image includes tools such as `onload_stackdump`. This troubleshooting container is suitable for interactive and automated use.
+
+### Interactive
+
+Create a privileged debugging container to run Onload troubleshooting tools interactively:
 
 ```console
 $ oc debug --image-stream=onload-clusterlocal/onload-diagnostics:v8.1.0 node/compute-0
@@ -253,6 +258,18 @@ sh-4.4# onload_stackdump
 #stack-id stack-name      pids
 0         -               4159878
 ```
+
+### Automated
+
+#### OpenShift
+
+Collect a log bundle via the OpenShift `must-gather` tool:
+
+```console
+$ oc adm must-gather --image-stream=onload-clusterlocal/onload-must-gather:v8.1.0 -- gather_onload
+```
+
+By default, the `oc adm must-gather` command writes into `./must-gather.local`.
 
 ## Deploying artifacts into an airgapped cluster
 

--- a/onload/build/diagnostics/Dockerfile
+++ b/onload/build/diagnostics/Dockerfile
@@ -4,6 +4,9 @@ FROM image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload
 
 FROM ubi8:8.8
 
+COPY collect_onload /usr/bin/
+RUN chmod ugo+rx /usr/bin/collect_onload
+
 RUN dnf install -y libpcap procps-ng util-linux iptables python3
 
 # Best effort to install tcpdump for onload_tcpdump.

--- a/onload/build/diagnostics/buildconfig-nameref.yaml
+++ b/onload/build/diagnostics/buildconfig-nameref.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+nameReference:
+- kind: ConfigMap
+  fieldSpecs:
+  - path: spec/source/configMaps/configMap/name
+    kind: BuildConfig

--- a/onload/build/diagnostics/buildconfig.yaml
+++ b/onload/build/diagnostics/buildconfig.yaml
@@ -7,9 +7,6 @@ metadata:
     app: onload-diagnostics
   name: onload-diagnostics
 spec:
-  nodeSelector:
-    node-role.kubernetes.io/worker: ""
-  runPolicy: Serial
   triggers:
     - type: ConfigChange
     - type: ImageChange
@@ -20,7 +17,9 @@ spec:
           namespace: onload-clusterlocal
   source:
     dockerfile: (placeholder)
-
+    configMaps:
+      - configMap:
+          name: onload-diagnostics-scripts
   strategy:
     dockerStrategy:
       buildArgs:
@@ -28,4 +27,27 @@ spec:
     to:
       kind: ImageStreamTag
       name: onload-diagnostics:v8.1.0
+      namespace: onload-clusterlocal
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: onload-diagnostics
+  name: onload-must-gather
+spec:
+  triggers:
+    - type: ConfigChange
+  source:
+    dockerfile: (placeholder)
+    configMaps:
+      - configMap:
+          name: onload-must-gather-scripts
+  strategy:
+    dockerStrategy:
+      buildArgs:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: onload-must-gather:v8.1.0
       namespace: onload-clusterlocal

--- a/onload/build/diagnostics/collect_onload
+++ b/onload/build/diagnostics/collect_onload
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+declare -r BASE_COLLECTION_PATH="/must-gather"
+
+
+collect_onload_stackdump() {
+  declare -r command=$1
+
+  echo "Running onload_stackdump ${command}"
+  onload_stackdump "${command}" |& tee -a "${BASE_COLLECTION_PATH}/${command}.log"
+}
+
+
+collect_onload() {
+  echo Collecting Onload diagnostics data
+
+  mkdir -p "${BASE_COLLECTION_PATH}"
+
+  collect_onload_stackdump lots
+  collect_onload_stackdump filters
+  collect_onload_stackdump filter_table
+}
+
+
+collect_onload

--- a/onload/build/diagnostics/kustomization.yaml
+++ b/onload/build/diagnostics/kustomization.yaml
@@ -9,6 +9,16 @@ configMapGenerator:
 - name: onload-diagnostics-dockerfile
   files:
   - dockerfile=Dockerfile
+- name: onload-diagnostics-scripts
+  files:
+  - collect_onload
+
+- name: onload-must-gather-dockerfile
+  files:
+  - dockerfile=must-gather/Dockerfile
+- name: onload-must-gather-scripts
+  files:
+  - must-gather/gather_onload
 
 replacements:
 - source:
@@ -21,3 +31,17 @@ replacements:
       name: onload-diagnostics
     fieldPaths:
     - spec.source.dockerfile
+
+- source:
+    kind: ConfigMap
+    name: onload-must-gather-dockerfile
+    fieldPath: data.dockerfile
+  targets:
+  - select:
+      kind: BuildConfig
+      name: onload-must-gather
+    fieldPaths:
+    - spec.source.dockerfile
+
+configurations:
+- buildconfig-nameref.yaml

--- a/onload/build/diagnostics/must-gather/ContainerFileNotice
+++ b/onload/build/diagnostics/must-gather/ContainerFileNotice
@@ -1,0 +1,46 @@
+NOTICE - BY INVOKING THIS SCRIPT AND USING THE SOFTWARE INSTALLED BY THE
+SCRIPT, YOU AGREE ON BEHALF OF YOURSELF AND YOUR EMPLOYER (IF APPLICABLE) TO BE
+BOUND TO THE LICENSE AGREEMENTS APPLICABLE TO THE PACKAGES IDENTIFIED BELOW
+THAT YOU INSTALL BY RUNNING THE SCRIPT. YOU UNDERSTAND THAT THE INSTALLATION OF
+THE PACKAGES LISTED BELOW MAY ALSO RESULT IN THE INSTALLATION ON YOUR SYSTEM OF
+ADDITIONAL PACKAGES NOT LISTED BELOW IN ORDER TO OPERATE (EACH, A
+‘DEPENDENCY’). ADVANCED MICRO DEVICES, INC., ON BEHALF OF ITSELF AND ITS
+SUBSIDIARIES AND AFFILIATES, DOES NOT GRANT TO YOU ANY RIGHTS OR LICENSES TO
+ANY SUCH DEPENDENCY. THE SCRIPT ITSELF IS LICENSED TO YOU SUBJECT TO THE
+FOLLOWING TERMS:
+
+Copyright © 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+
+This file is licensed under the following license terms (MIT):
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+This file pulls in the following packages subject to the licenses identified
+below:
+
+| Package, Version                 | License      | URL                                                                                    |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|
+| OpenShift CLI Client, 4.12       | Apache-2.0   | https://github.com/openshift/oc/blob/openshift-clients-4.12.0-202208031327/LICENSE     |
+|                                  | GPL-2+       |                                                                                        |
+|                                  | + Various    |                                                                                        |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|
+| AMD Onload, 8.1                  | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/v8.1.0/src/onload/distfiles/LICENSE          |
+|                                  | AND          |                                                                                        |
+|                                  | BSD-2-Clause |                                                                                        |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/onload/build/diagnostics/must-gather/Dockerfile
+++ b/onload/build/diagnostics/must-gather/Dockerfile
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+FROM openshift4/ose-cli:v4.12.0
+
+COPY gather_onload /usr/bin/
+RUN chmod ugo+rx /usr/bin/gather_onload

--- a/onload/build/diagnostics/must-gather/gather_onload
+++ b/onload/build/diagnostics/must-gather/gather_onload
@@ -1,0 +1,97 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+declare -r BASE_COLLECTION_PATH="/must-gather"
+declare COLLECTION_PATH="${BASE_COLLECTION_PATH}"
+
+declare -r NAMESPACE="onload-runtime"
+declare -r IMAGE_STREAM="onload-clusterlocal/onload-diagnostics:v8.1.0"
+declare -r NODE_SELECTOR="node-role.kubernetes.io/worker"
+
+declare -r USAGE="Onload must-gather script for OpenShift clusters
+
+Run as a standalone script with the --collection-path option
+to override the default output directory:
+
+  $ ./gather_onload --collection-path onload-bundle
+
+Run with must-gather, optionally with the --dest-dir option
+to override the default directory ./must-gather.local:
+
+  $ oc adm must-gather --image-stream=onload-clusterlocal/onload-must-gather:v8.1.0 -- gather_onload
+
+Options:
+
+  --collection-path  Output directory with the collected logs (default=${BASE_COLLECTION_PATH})
+  -h|--help          Print this message
+"
+
+
+gather_onload_off_node() {
+  local -r node="$1"
+
+  # Get the debug pod's name without starting it.
+  local -r debug_pod=$(oc debug --to-namespace="${NAMESPACE}" \
+                                --image-stream="${IMAGE_STREAM}" \
+                                --output jsonpath='{.metadata.name}' \
+                                node/"${node}")
+  if [[ -z "$debug_pod" ]]
+  then
+    echo "Unable to obtain a debug pod for node ${node}"
+  fi
+
+  # Spin up the pod.
+  oc debug --to-namespace="${NAMESPACE}" --image-stream="${IMAGE_STREAM}" node/"${node}" \
+    -- sleep 300 > /dev/null 2>&1 &
+
+  # Allow the pod to register.
+  sleep 2
+  oc wait -n "${NAMESPACE}" --for=condition=Ready pod/"$debug_pod" --timeout=30s
+
+  # Collect Onload diagnostics.
+  oc rsh -n "${NAMESPACE}" "${debug_pod}" collect_onload
+
+  # Copy the files across.
+  mkdir -p "${COLLECTION_PATH}/${node}"
+  oc rsync -n "${NAMESPACE}" \
+    "${debug_pod}:${BASE_COLLECTION_PATH}"/ \
+    "${COLLECTION_PATH}/${node}"
+
+  # Terminate the debugging pod.
+  oc delete pod -n "${NAMESPACE}" "${debug_pod}"
+}
+
+
+gather_onload() {
+  local -r nodes="$(oc get nodes --selector=${NODE_SELECTOR} -o jsonpath='{.items[*].metadata.name}')"
+
+  for node in ${nodes}
+  do
+    gather_onload_off_node "${node}"
+  done
+}
+
+
+while [[ $# -gt 0 ]]
+do
+  case $1 in
+    --collection-path)
+      COLLECTION_PATH="$2"
+      shift
+      shift
+      ;;
+    -h|--help)
+      echo "${USAGE}"
+      exit
+      ;;
+    *)
+      echo "Unknown command line option: $1"
+      echo "${USAGE}"
+      exit
+      ;;
+  esac
+done
+
+
+gather_onload

--- a/onload/imagestream/imagestream.yaml
+++ b/onload/imagestream/imagestream.yaml
@@ -46,3 +46,10 @@ metadata:
   name: onload-diagnostics
   namespace: onload-clusterlocal
 spec: {}
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: onload-must-gather
+  namespace: onload-clusterlocal
+spec: {}


### PR DESCRIPTION
Add a new diagnostics image for the automated log collection in the OpenShift clusters with `oc adm must-gather`. The collection script is also runnable as a standalone script.

Additionally, add a new script in the onload-diagnostics image with the selected Onload log collection commands.

Reviewed-by: Peter Colledge <peter.colledge@amd.com>

---

Notes:
1. The sfreport tool is not included in the latest incarnation of this PR. We should implement SWUTILS-902 first and then pull the script from a public git repo.
2. An alternative collection method https://artifacthub.io/packages/krew/krew-index/support-bundle was considered, but it is lacking features to dynamically generate Onload logs across multiple nodes. For instance, the `runPod` or `exec` [collectors](https://troubleshoot.sh/docs/collect/all/) spin up only one pod and can't collect files. The `logs` collector can collect files on multiple nodes, but it requires deploying a diagnostics daemon set and a triggering implementation, potentially non-trivial).
3. The scope of the logs is limited to Onload. If we need more logs, I suggest we require two runs of `oc adm must-gather`: one for Onload and another for OCP-specific logs.

Testing:

```console
$ oc adm must-gather --image-stream=onload-clusterlocal/onload-must-gather:v8.1.0 -- gather_onload
$ tree must-gather.local.4857219228637955729
must-gather.local.4857219228637955729
├── event-filter.html
├── image-registry-openshift-image-registry-svc-5000-onload-clusterlocal-onload-must-gather-sha256-c1c15779aec6875cf02963c588219d342e56ae1380a7a5722a0a42ef9ddab70f
│   ├── compute-0
│   │   ├── filters.log
│   │   ├── filter_table.log
│   │   └── lots.log
│   └── compute-1
│       ├── filters.log
│       ├── filter_table.log
│       └── lots.log
└── timestamp

3 directories, 8 files
```

For development, run `gather_onload` without `oc adm must-gather`:
```console
$ cd onload/build/diagnostics/must-gather
$ ./gather_onload --collection-path onload-bundle
$ tree onload-bundle/
onload-bundle/
├── compute-0
│   ├── filters.log
│   ├── filter_table.log
│   └── lots.log
└── compute-1
    ├── filters.log
    ├── filter_table.log
    └── lots.log

2 directories, 6 files
```