### PR TITLE
ON-15121: Create control plane daemon set

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - kmm.sigs.x-k8s.io
   resources:
   - modules

--- a/controllers/onload_controller.go
+++ b/controllers/onload_controller.go
@@ -12,15 +12,27 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kmm "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 
 	onloadv1alpha1 "github.com/Xilinx-CNS/kubernetes-onload/api/v1alpha1"
+	"k8s.io/utils/ptr"
 )
+
+const controlPlaneScript = `
+set -e;
+echo /usr/bin/crictl | tee /sys/module/onload/parameters/cplane_server_path;
+declare -r container_id=$(awk -F'[-./]' '/crio-/{print $(NF - 1); exit}' /proc/self/cgroup);
+echo exec ${container_id} /opt/onload/sbin/onload_cp_server -K | tee /sys/module/onload/parameters/cplane_server_params;
+sleep infinity;
+`
 
 // OnloadReconciler reconciles a Onload object
 type OnloadReconciler struct {
@@ -32,6 +44,7 @@ type OnloadReconciler struct {
 //+kubebuilder:rbac:groups=onload.amd.com,resources=onloads/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=onload.amd.com,resources=onloads/finalizers,verbs=update
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -80,6 +93,11 @@ func (r *OnloadReconciler) Reconcile(
 		return res, err
 	}
 
+	err = r.createControlPlaneDaemonSet(ctx, onload)
+	if err != nil {
+		log.Error(err, "Failed to create control plane daemon set")
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -179,6 +197,80 @@ func createModule(
 	}
 
 	return module, nil
+}
+
+func (r *OnloadReconciler) createControlPlaneDaemonSet(
+	ctx context.Context, onload *onloadv1alpha1.Onload,
+) error {
+	log := log.FromContext(ctx)
+
+	dsName := onload.Name + "-onload-cplane-ds"
+
+	// Create the control plane daemon set only if it has not been created.
+	ds := &appsv1.DaemonSet{}
+	err := r.Get(
+		ctx,
+		types.NamespacedName{
+			Name:      dsName,
+			Namespace: onload.Namespace,
+		},
+		ds,
+	)
+
+	if err == nil {
+		log.Info("The control plane daemon set exists")
+		return nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	container := v1.Container{
+		Name:            onload.Name + "-onload-cplane",
+		Image:           onload.Spec.Onload.UserImage,
+		ImagePullPolicy: onload.Spec.Onload.ImagePullPolicy,
+		Command:         []string{"/bin/sh", "-c"},
+		Args:            []string{controlPlaneScript},
+		SecurityContext: &v1.SecurityContext{
+			Privileged: ptr.To(true),
+		},
+	}
+
+	dsLabels := map[string]string{
+		"onload.amd.com/name": dsName,
+	}
+
+	log.Info("Creating control plane daemon set")
+	ds = &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName,
+			Namespace: onload.Namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: dsLabels},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: dsLabels,
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: onload.Spec.ServiceAccountName,
+					NodeSelector:       onload.Spec.Selector,
+					HostNetwork:        true,
+					HostPID:            true,
+					HostIPC:            true,
+					Containers:         []v1.Container{container},
+				},
+			},
+		},
+	}
+
+	err = controllerutil.SetControllerReference(onload, ds, r.Scheme)
+	if err != nil {
+		return err
+	}
+
+	return r.Create(ctx, ds)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	k8s.io/component-base v0.27.2 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230515203736-54b630e78af5 // indirect
-	k8s.io/utils v0.0.0-20230505201702-9f6742963106 // indirect
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -733,6 +733,8 @@ k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 h1:KTgPnR10d5zhztWptI952TNtt/4u5
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20230505201702-9f6742963106 h1:EObNQ3TW2D+WptiYXlApGNLVy0zm/JIBVY9i+M4wpAU=
 k8s.io/utils v0.0.0-20230505201702-9f6742963106/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
A draft until these work items are done:

- [x] Rebase on top of https://github.com/Xilinx-CNS/kubernetes-onload/pull/46.
- [x] Reuse the `ServiceAccountName` field added in both PRs.
- [ ] ~Delete DS manually before deleting Module to facilitate the ordering.~
- [x] Add test coverage: test if the reconciler calls `Create()` only if `Get()` returns `IsNotFound()`.

---

The operator reconciliation spawns the control plane daemon set that registers itself with the kernel module set shortly afterwards:

```console
$ oc apply -k config/samples
$ dmesg
[  +0.000023] [onload] Copyright (c) 2002-2023 Advanced Micro Devices, Inc.
[  +0.003796] [onload] oo_nic_add: ifindex=3046 oo_index=0
[Aug21 09:03] onload_cp_server[2418478]: Onload Control Plane server   started: id 0, pid 2418478
[  +0.003175] onload_cp_server[2418478]: Accelerating sf0: RX 1 TX 1
```

Testing:
```console
$ make test
KUBEBUILDER_ASSETS="/home/iteterev/lab/kubernetes-onload/bin/k8s/1.26.0-linux-amd64" go test ./... -coverprofile cover.out
?       github.com/Xilinx-CNS/kubernetes-onload [no test files]
?       github.com/Xilinx-CNS/kubernetes-onload/api/v1alpha1    [no test files]
ok      github.com/Xilinx-CNS/kubernetes-onload/controllers     7.311s  coverage: 74.6% of statements
```
