### PR TITLE
ON-14911: Add control plane daemon set image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY internal/ internal/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/api/v1alpha1/onload_types.go
+++ b/api/v1alpha1/onload_types.go
@@ -95,6 +95,10 @@ type Spec struct {
 
 	// Selector defines the set of nodes that this onload CR will run on.
 	Selector map[string]string `json:"selector"`
+
+	// ServiceAccountName is the name of the service account that the objects
+	// created by the onload operator will use.
+	ServiceAccountName string `json:"serviceAccountName"`
 }
 
 // OnloadStatus defines the observed state of Onload

--- a/config/crd/bases/onload.amd.com_onloads.yaml
+++ b/config/crd/bases/onload.amd.com_onloads.yaml
@@ -115,10 +115,15 @@ spec:
                 description: Selector defines the set of nodes that this onload CR
                   will run on.
                 type: object
+              serviceAccountName:
+                description: ServiceAccountName is the name of the service account
+                  that the objects created by the onload operator will use.
+                type: string
             required:
             - devicePlugin
             - onload
             - selector
+            - serviceAccountName
             type: object
           status:
             description: Status contains the statuses for onload and related products

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - onload.amd.com
   resources:
   - onloads

--- a/config/samples/onload_v1alpha1_onload.yaml
+++ b/config/samples/onload_v1alpha1_onload.yaml
@@ -1,5 +1,36 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: onload-operator-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: onload-operator-role
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - privileged
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: onload-operator-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: onload-operator-role
+subjects:
+- kind: ServiceAccount
+  name: onload-operator-sa
+---
 apiVersion: onload.amd.com/v1alpha1
 kind: Onload
 metadata:
@@ -11,6 +42,7 @@ metadata:
     app.kubernetes.io/created-by: onload-operator
   name: onload-sample
 spec:
+  serviceAccountName: onload-operator-sa
   selector:
     node-role.kubernetes.io/worker: ""
   onload:

--- a/controllers/onload_controller.go
+++ b/controllers/onload_controller.go
@@ -7,14 +7,31 @@ import (
 	"context"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	onloadv1alpha1 "github.com/Xilinx-CNS/kubernetes-onload/api/v1alpha1"
+	"github.com/Xilinx-CNS/kubernetes-onload/internal/utils"
 )
+
+const cpdsLabel = "onload.amd.com/name"
+const cpdsSuffix = "-onload-cplane-ds"
+const cpdsPodSuffix = "-onload-cplane"
+
+const cpdsScript = `
+echo /usr/bin/crictl | tee /sys/module/onload/parameters/cplane_server_path;
+declare -r container_id=$(awk -F'[-./]' '/crio-/{print $(NF - 1); exit}' /proc/self/cgroup);
+echo exec ${container_id} /opt/onload/sbin/onload_cp_server -K | tee /sys/module/onload/parameters/cplane_server_params;
+sleep infinity;
+`
 
 // OnloadReconciler reconciles a Onload object
 type OnloadReconciler struct {
@@ -22,9 +39,96 @@ type OnloadReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+func (r *OnloadReconciler) createControlPlaneDaemonSet(
+	ctx context.Context, onload *onloadv1alpha1.Onload,
+) error {
+	dsName := onload.Name + cpdsSuffix
+
+	// Create the control plane daemon set only if it has not been created.
+	ds := &appsv1.DaemonSet{}
+	err := r.Get(
+		ctx,
+		types.NamespacedName{
+			Name:      dsName,
+			Namespace: onload.Namespace,
+		},
+		ds,
+	)
+	if err == nil || !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	container := v1.Container{
+		Name:            onload.Name + cpdsPodSuffix,
+		Image:           onload.Spec.Onload.UserImage,
+		ImagePullPolicy: v1.PullAlways,
+		Command:         []string{"/bin/sh", "-c"},
+		Args:            []string{cpdsScript},
+		SecurityContext: &v1.SecurityContext{
+			Privileged: utils.NewBoolPointer(true),
+		},
+	}
+
+	dsLabels := map[string]string{
+		cpdsLabel: dsName,
+	}
+
+	ds = &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName,
+			Namespace: onload.Namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: dsLabels},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: dsLabels,
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: onload.Spec.ServiceAccountName,
+					NodeSelector:       onload.Spec.Selector,
+					HostNetwork:        true,
+					HostPID:            true,
+					HostIPC:            true,
+					Containers:         []v1.Container{container},
+				},
+			},
+		},
+	}
+
+	err = controllerutil.SetControllerReference(onload, ds, r.Scheme)
+	if err != nil {
+		return err
+	}
+
+	return r.Create(ctx, ds)
+}
+
+func (r *OnloadReconciler) deleteControlPlaneDaemonSet(
+	ctx context.Context, onload *onloadv1alpha1.Onload,
+) error {
+	dsName := onload.Name + cpdsSuffix
+
+	ds := &appsv1.DaemonSet{}
+	err := r.Get(
+		ctx,
+		types.NamespacedName{
+			Name:      dsName,
+			Namespace: onload.Namespace,
+		},
+		ds,
+	)
+	if err != nil {
+		return err
+	}
+
+	return r.Delete(ctx, ds)
+}
+
 //+kubebuilder:rbac:groups=onload.amd.com,resources=onloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=onload.amd.com,resources=onloads/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=onload.amd.com,resources=onloads/finalizers,verbs=update
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -60,8 +164,16 @@ func (r *OnloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Info("Adding new Onload kind")
 	} else {
 		log.Info("Deleting new Onload kind")
+
+		err = r.deleteControlPlaneDaemonSet(ctx, onload)
+		return ctrl.Result{}, err
 	}
 
+	err = r.createControlPlaneDaemonSet(ctx, onload)
+	if err != nil {
+		log.Error(err, "Failed to create control plane daemon set")
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/images/control-plane.yaml
+++ b/images/control-plane.yaml
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: onload-control-plane
+spec: {}
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: onload-control-plane
+spec:
+  runPolicy: "Serial"
+  triggers:
+    - type: "ConfigChange"
+  source:
+    dockerfile: |
+      # Supply of onload_cp_server
+      FROM image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-user:v8.1.0 AS onload-user
+
+      # Runtime with kubectl & jq
+      FROM alpine/k8s:1.25.12
+
+      COPY --from=onload-user /opt/onload/sbin/onload_cp_server /sbin/
+  strategy:
+    dockerStrategy:
+      buildArgs:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: onload-control-plane:v8.1.0
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: onload-control-plane-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: onload-control-plane-role
+rules:
+# Allow API requests with kubectl
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  # kubectl watch
+  - list
+  - watch
+
+  # kubectl get pod
+  - get
+# Allow running in the host namespaces
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - privileged
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: onload-control-plane-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: onload-control-plane-role
+subjects:
+- kind: ServiceAccount
+  name: onload-control-plane-sa
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: onload-control-plane-ds
+spec:
+  selector:
+    matchLabels:
+      name: onload-control-plane-ds
+  template:
+    metadata:
+      labels:
+        name: onload-control-plane-ds
+    spec:
+      serviceAccount: onload-control-plane-sa
+      serviceAccountName: onload-control-plane-sa
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      containers:
+      - name: onload-control-plane
+        image: image-registry.openshift-image-registry.svc:5000/default/onload-control-plane:v8.1.0
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - |
+          set -e
+
+          kubectl wait --for=condition=Ready pod/${POD_NAME}
+          export CONTAINER_ID=$(kubectl get pod -n ${POD_NAMESPACE} -ojson ${POD_NAME} | jq -r '.status.containerStatuses[] | select(.name == "onload-control-plane") | .containerID' | sed 's|cri-o://||g')
+
+          echo /usr/bin/crictl | tee /sys/module/onload/parameters/cplane_server_path
+          echo exec ${CONTAINER_ID} /sbin/onload_cp_server -K | tee /sys/module/onload/parameters/cplane_server_params
+
+          sleep infinity
+
+        securityContext:
+          privileged: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+package utils
+
+func NewBoolPointer(v bool) *bool {
+	return &v
+}


### PR DESCRIPTION
This pull request wants to get away without spinning up a new repository for the container ID finder in the absence of the corresponding downward API field. It pulls the alpine/k8s image from Docker Hub, copies the Onload control plane binary into it, and finally makes a couple of kubectl invocations, constrained with the get and list verbs. The image license is MIT: https://github.com/alpine-docker/k8s/blob/master/LICENSE.

It is a draft which I don't want to merge as-is because it depends on the build time, not yet established in the master branch.

Testing logs:
```console
$ oc logs onload-control-plane-ds-6fwrp
pod/onload-control-plane-ds-6fwrp condition met
/usr/bin/crictl
exec 0418fafb26cc165d612050a8b700d24e74bb8d00fadd9d8d5cd43f3cd16f0bac /sbin/onload_cp_server -K
```