### PR TITLE
ON-15120: Allow controller setting finalizers on Onload resources

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -33,6 +33,12 @@ rules:
 - apiGroups:
   - onload.amd.com
   resources:
+  - onloads/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - onload.amd.com
+  resources:
   - onloads/status
   verbs:
   - get

--- a/controllers/onload_controller.go
+++ b/controllers/onload_controller.go
@@ -31,6 +31,7 @@ type OnloadReconciler struct {
 //+kubebuilder:rbac:groups=onload.amd.com,resources=onloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=onload.amd.com,resources=onloads/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=onload.amd.com,resources=onloads/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
The patch fixes this error:
```
2023-08-22T13:38:51Z ERROR Failed to create new module {
  "controller": "onload",
  "controllerGroup": "onload.amd.com",
  "controllerKind": "Onload",
  "Onload": {
    "name": "onload-sample",
    "namespace": "default"
  },
  "namespace": "default",
  "name": "onload-sample",
  "reconcileID": "372710d8-21aa-463b-8c07-7d2031d9bf8f",
  "error": "modules.kmm.sigs.x-k8s.io \"onload-sample-onload-module\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"
}
```