### PR TITLE
ON-14911: Add onload-worker container to device plugin DaemonSet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,12 @@ docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
 .PHONY: device-plugin-build
-device-plugin-build: manifests generate fmt vet ## Build device plugin
-	go build ./cmd/deviceplugin/
+device-plugin-build: ## Build Onload Device Plugin.
+	go build -o ./bin/onload-device-plugin ./cmd/deviceplugin/
+
+.PHONY: worker-build
+worker-build: ## Build Onload worker app.
+	go build -o ./bin/onload-worker ./cmd/worker
 
 .PHONY: device-plugin-docker-build
 device-plugin-docker-build: test ## Build docker image with the manager.

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+
+	"github.com/Xilinx-CNS/kubernetes-onload/pkg/client_helper"
+	"github.com/Xilinx-CNS/kubernetes-onload/pkg/control_plane"
+)
+
+func main() {
+	// Enable logging to stderr.
+	flag.Parse()
+	err := flag.Lookup("logtostderr").Value.Set("true")
+	if err != nil {
+		glog.Fatalf("Failed to initialise Onload worker: %v", err)
+	}
+
+	// Get the container identification from env.
+	podNamespace := os.Getenv("POD_NAMESPACE")
+	podName := os.Getenv("POD_NAME")
+	containerName := os.Getenv("CONTAINER_NAME")
+
+	// A mount point with the Onload control plane server.
+	onloadCPServerPath := os.Getenv("ONLOAD_CP_SERVER_PATH")
+
+	// There is a race condition when the container is starting, and the
+	// Onload kernel module is loading at the same time, resulting in not
+	// all files being available in the container.
+	_, err = os.Stat("/dev/onload")
+	if err != nil {
+		glog.Fatalf("/dev/onload is not available: %v", err)
+	}
+
+	// Create an API helper to get the container ID.
+	clientHelper, err := client_helper.NewClientHelper()
+	if err != nil {
+		glog.Fatal("Failed to create K8s helper: ", err)
+	}
+
+	// Prepare a context with timeout for API calls.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	containerID, err := clientHelper.GetContainerID(ctx,
+		podNamespace, podName,
+		client_helper.NewDefaultContainerHelper(containerName))
+	if err != nil {
+		glog.Fatal("Failed to get container ID: ", err)
+	}
+
+	glog.Info("Found container ID ", containerID)
+
+	// Configure Onload kernel module to launch
+	// Onload control plane within a container.
+	err = control_plane.Configure(onloadCPServerPath, containerID,
+		control_plane.NewKernelParametersWriter())
+	if err != nil {
+		glog.Fatal("Failed to configure Onload control plane: ", err)
+	}
+
+	// Sleep forever.
+	select {}
+}

--- a/config/samples/onload_v1alpha1_onload.yaml
+++ b/config/samples/onload_v1alpha1_onload.yaml
@@ -18,6 +18,12 @@ rules:
   - use
   resourceNames:
   - privileged
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/controllers/onload_controller_test.go
+++ b/controllers/onload_controller_test.go
@@ -153,30 +153,6 @@ var _ = Describe("onload controller", func() {
 				})))
 		})
 
-		It("should create the control plane daemon set", func() {
-			createdControlPlane := appsv1.DaemonSet{}
-			controlPlaneName := types.NamespacedName{
-				Name:      onload.Name + "-onload-cplane-ds",
-				Namespace: onload.Namespace,
-			}
-
-			By("creating an onload CR")
-			Expect(k8sClient.Create(ctx, onload)).To(BeNil())
-
-			By("checking for the existence of the control plane daemon set")
-			Eventually(func() error {
-				return k8sClient.Get(ctx, controlPlaneName,
-					&createdControlPlane)
-			}, timeout, pollingInterval).Should(BeNil())
-
-			By("checking the owner references of the module")
-			Expect(createdControlPlane.ObjectMeta.OwnerReferences).
-				To(ContainElement(MatchFields(IgnoreExtras, Fields{
-					"Name": Equal(onload.Name),
-					"UID":  Equal(onload.UID),
-				})))
-		})
-
 		It("should create a device plugin daemonset", func() {
 			devicePlugin := appsv1.DaemonSet{}
 			devicePluginName := types.NamespacedName{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
-
 package controllers
 
 import (

--- a/deviceplugin.Dockerfile
+++ b/deviceplugin.Dockerfile
@@ -8,12 +8,18 @@ COPY go.mod /app/go.mod
 COPY go.sum /app/go.sum
 RUN go mod download
 
-COPY pkg/deviceplugin /app/pkg/deviceplugin
-COPY cmd/deviceplugin /app/cmd/deviceplugin
+COPY Makefile /app/Makefile
 
-RUN go build -o /app/onload-plugin ./cmd/deviceplugin
+COPY pkg/client_helper /app/pkg/client_helper
+COPY pkg/control_plane /app/pkg/control_plane
+COPY pkg/deviceplugin /app/pkg/deviceplugin
+
+COPY cmd/deviceplugin /app/cmd/deviceplugin
+COPY cmd/worker /app/cmd/worker
+
+RUN make device-plugin-build worker-build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 RUN microdnf install lshw
-COPY --from=builder /app/onload-plugin /usr/bin/onload-plugin
-CMD ["/usr/bin/onload-plugin"]
+COPY --from=builder /app/bin/onload-device-plugin /app/bin/onload-worker /usr/bin/
+CMD ["/usr/bin/onload-device-plugin"]

--- a/pkg/client_helper/client_helper.go
+++ b/pkg/client_helper/client_helper.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+package client_helper
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ClientHelper struct {
+	Config *rest.Config
+}
+
+// Create the new helper with the in-cluster config.
+func NewClientHelper() (*ClientHelper, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClientHelper{
+		Config: config,
+	}, nil
+}
+
+type ContainerHelper interface {
+	GetContainerID(pod *corev1.Pod) *string
+}
+
+type DefaultContainerHelper struct {
+	ContainerName string
+}
+
+func (h *DefaultContainerHelper) GetContainerID(pod *corev1.Pod) *string {
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name != h.ContainerName {
+			continue
+		}
+
+		if status.Ready && *status.Started && status.State.Running != nil {
+			return &status.ContainerID
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func NewDefaultContainerHelper(containerName string) ContainerHelper {
+	return &DefaultContainerHelper{
+		ContainerName: containerName,
+	}
+}
+
+const (
+	backOffInitial = 100 * time.Millisecond
+	backOffMax     = 1 * time.Second
+
+	backOffID = "defaultBackOff"
+)
+
+// Get ID of the container identified by the pod's name, namespace
+// and also the container's name if there are more than one in the pod.
+// The returned string is in the format "<type>://<container_id>".
+func (ch *ClientHelper) GetContainerID(ctx context.Context,
+	podNamespace string, podName string, helper ContainerHelper,
+) (string, error) {
+	cs, err := kubernetes.NewForConfig(ch.Config)
+	if err != nil {
+		return "", err
+	}
+
+	backOff := flowcontrol.NewBackOff(backOffInitial, backOffMax)
+
+	for {
+		pod, err := cs.CoreV1().Pods(podNamespace).Get(
+			ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+
+		containerID := helper.GetContainerID(pod)
+		if containerID != nil {
+			return *containerID, nil
+		}
+
+		backOff.Next(backOffID, time.Now())
+
+		select {
+		case <-time.After(backOff.Get(backOffID)):
+			continue
+		case <-ctx.Done():
+			return "", context.DeadlineExceeded
+		}
+	}
+}

--- a/pkg/client_helper/client_helper_test.go
+++ b/pkg/client_helper/client_helper_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+package client_helper
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+type mockContainerHelper struct {
+	mockContainerID *string
+}
+
+func (m *mockContainerHelper) GetContainerID(*corev1.Pod) *string {
+	return m.mockContainerID
+}
+
+var _ = Describe("Test GetContainerID API function", func() {
+	It("Should return container ID", func() {
+		clientHelper := &ClientHelper{
+			Config: cfg,
+		}
+
+		// This test does not require a context with the timeout,
+		// but we still create it to prevent blocking forever in
+		// the case of a software defect.
+		timeoutContext, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		containerID, err := clientHelper.GetContainerID(
+			timeoutContext, mockNamespaceName, mockPodName,
+			&mockContainerHelper{
+				mockContainerID: &mockContainerName,
+			})
+
+		Expect(err).Should(Succeed())
+		Expect(containerID).To(Equal(mockContainerName))
+	})
+
+	It("Should timeout because container helper is mocking not-found behaviour", func() {
+		clientHelper := &ClientHelper{
+			Config: cfg,
+		}
+
+		timeoutContext, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		containerID, err := clientHelper.GetContainerID(
+			timeoutContext, mockNamespaceName, mockPodName,
+			&mockContainerHelper{
+				mockContainerID: nil,
+			})
+
+		Expect(err).To(Equal(context.DeadlineExceeded))
+		Expect(containerID).To(Equal(""))
+	})
+})
+
+var _ = Describe("Test internal container helper", func() {
+	var mockFooContainerName = "foo-running"
+	var mockBarContainerName = "bar-not-running"
+	var mockBazContainerName = "baz-does-not-exist"
+
+	var mockFooContainerID = "cri-o://0123456789abcdef"
+
+	mockPod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    mockFooContainerName,
+					Ready:   true,
+					Started: ptr.To(true),
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+					ContainerID: mockFooContainerID,
+				},
+				{
+					Name:  mockBarContainerName,
+					Ready: false,
+				},
+			},
+		},
+	}
+
+	It("Should find running container", func() {
+		containerID := NewDefaultContainerHelper(mockFooContainerName).GetContainerID(mockPod)
+		Expect(*containerID).To(Equal(mockFooContainerID))
+	})
+
+	It("Should find container but return nil because it is not running", func() {
+		containerID := NewDefaultContainerHelper(mockBarContainerName).GetContainerID(mockPod)
+		Expect(containerID).To(BeNil())
+	})
+
+	It("Should not find container", func() {
+		containerID := NewDefaultContainerHelper(mockBazContainerName).GetContainerID(mockPod)
+		Expect(containerID).To(BeNil())
+	})
+})

--- a/pkg/client_helper/suite_test.go
+++ b/pkg/client_helper/suite_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+package client_helper
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"testing"
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+// Must be a variable to get its address.
+var mockContainerName string = "mock-container"
+
+func TestK8sHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Go clients Helper Suite")
+}
+
+const (
+	mockNamespaceName = "mock-namespace"
+	mockPodName       = "mock-pod"
+
+	mockImage = "mock-image"
+)
+
+var (
+	ctx    context.Context
+	cancel context.CancelFunc
+)
+
+var _ = BeforeSuite(func() {
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("Bootstrapping test environment")
+	testEnv = &envtest.Environment{}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// Creating mock resources.
+
+	// Warning! There are no built-in controllers that are running
+	// in the test context. It means that the DaemonSet won't create
+	// Pods, Pods won't create Containers, etc.
+	mockNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mockNamespaceName,
+		},
+	}
+	Expect(k8sClient.Create(ctx, mockNamespace)).To(Succeed())
+
+	mockPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mockPodName,
+			Namespace: mockNamespaceName,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				corev1.Container{
+					Name:  mockContainerName,
+					Image: mockImage,
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, mockPod)).To(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("Tearing down test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/control_plane/control_plane.go
+++ b/pkg/control_plane/control_plane.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+package control_plane
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// Configure the loaded Onload kernel module to launch
+// the Onload control plane process within a container.
+func Configure(
+	onloadCPServerPath string, containerID string, kpw KernelParametersWriter,
+) error {
+	// Split the container runtime type from identifier.
+	containerID, found := strings.CutPrefix(containerID, "cri-o://")
+	if !found {
+		return fmt.Errorf("Unsupported container runtime in %s", containerID)
+	}
+
+	glog.Info("CRI-O container ID is ", containerID)
+
+	// Set the Onload control plane path.
+	crictlPath := "/usr/bin/crictl"
+	err := kpw.SetControlPlaneServerPath(crictlPath)
+	if err != nil {
+		return err
+	}
+
+	glog.Info("Updated Onload control plane server path to ", crictlPath)
+
+	// Set the Onload control plane params.
+	params := fmt.Sprintf("exec %s %s -K", containerID, onloadCPServerPath)
+	err = kpw.SetControlPlaneServerParams(params)
+	if err != nil {
+		return err
+	}
+
+	glog.Info("Updated Onload control plane server params to ", params)
+
+	return nil
+}

--- a/pkg/control_plane/control_plane_test.go
+++ b/pkg/control_plane/control_plane_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+package control_plane
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	mockPodNamespace  = "mockPodNamespace"
+	mockPodName       = "mockPodName"
+	mockContainerName = "mockContainerName"
+
+	mockOnloadCPServerPath = "/mock/sbin/onload_cp_server"
+
+	mockCRIOContainerID       = "cri-o://0123456789abcdef"
+	mockContainerdContainerID = "containerd://fedcba9876543210"
+)
+
+type mockKernelParametersWriter struct {
+}
+
+func NewMockKernelParametersWriter() KernelParametersWriter {
+	return &mockKernelParametersWriter{}
+}
+
+func (*mockKernelParametersWriter) SetControlPlaneServerPath(path string) error {
+	Expect(path).To(Equal("/usr/bin/crictl"))
+	return nil
+}
+
+func (*mockKernelParametersWriter) SetControlPlaneServerParams(params string) error {
+	Expect(params).To(Equal("exec 0123456789abcdef /mock/sbin/onload_cp_server -K"))
+	return nil
+}
+
+var _ = Describe("Configure Onload to launch the control plane process within a container", func() {
+	It("Should work with the CRI-O runtime", func() {
+		err := Configure(mockOnloadCPServerPath, mockCRIOContainerID,
+			NewMockKernelParametersWriter())
+		Expect(err).Should(Succeed())
+	})
+
+	It("Should fail with non CRI-O runtime, e.g. containerd", func() {
+		err := Configure(mockOnloadCPServerPath, mockContainerdContainerID,
+			NewMockKernelParametersWriter())
+		Expect(err).Should(HaveOccurred())
+	})
+})

--- a/pkg/control_plane/kernel_parameters.go
+++ b/pkg/control_plane/kernel_parameters.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+package control_plane
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Provides access to the Onload sysfs configuration knobs.
+type KernelParametersWriter interface {
+	SetControlPlaneServerPath(path string) error
+	SetControlPlaneServerParams(params string) error
+}
+
+type kernelParametersWriter struct {
+}
+
+func NewKernelParametersWriter() KernelParametersWriter {
+	return &kernelParametersWriter{}
+}
+
+func writeOnloadParameterFile(where string, what string) error {
+	where = filepath.Join("/sys/module/onload/parameters", where)
+	return os.WriteFile(where, []byte(what), 0644)
+}
+
+func (kernelParametersWriter) SetControlPlaneServerPath(path string) error {
+	return writeOnloadParameterFile("cplane_server_path", path)
+}
+
+func (kernelParametersWriter) SetControlPlaneServerParams(params string) error {
+	return writeOnloadParameterFile("cplane_server_params", params)
+}

--- a/pkg/control_plane/suite_test.go
+++ b/pkg/control_plane/suite_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+package control_plane
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestOnload(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Onload Control Plane Suite")
+}


### PR DESCRIPTION
Add the new "onload-worker" container to the existing device plugin DaemonSet.

The new container provides the Onload control plane binary to the Onload kernel instead of the dedicated control plane DaemonSet, which the next patch will remove. Additionally, it manages (`chcon` and `rm`) the Onload files in the host. Hence its name is "onload-worker".

Unlike the control plane DaemonSet, the new container uses the Golang API to get the container ID instead of the cgroup workaround.

The new GetContainerID() function resides in the "pkg" directory and is suitable for reuse.

---

It is a draft until I finish with:

- [x] Remove the control plane DaemonSet. (A separate commit).
- [x] Pass the Onload control plane binary via EmptyDir. (It currently takes it from the host.)
- [x] Add test coverage, at least for the timeout feature of the "container-id" tool. (Not sure what's the best way to test the API call.)

---

Testing notes:

The new container does what it needs to do:
```console
$ oc logs -c onload-worker onload-sample-onload-device-plugin-ds-ltmrh
I0905 10:31:22.374698 2272581 control_plane.go:28] Container ID is cri-o://7e6c4c39a4db4a7333fbf285553b93a16f7730dd156e0e69056ebc6ac3f7a677
I0905 10:31:22.374779 2272581 control_plane.go:36] CRI-O container ID is 7e6c4c39a4db4a7333fbf285553b93a16f7730dd156e0e69056ebc6ac3f7a677
I0905 10:31:22.375157 2272581 control_plane.go:45] Updated Onload control plane server path to /usr/bin/crictl
I0905 10:31:22.375412 2272581 control_plane.go:55] Updated Onload control plane server params to exec 7e6c4c39a4db4a7333fbf285553b93a16f7730dd156e0e69056ebc6ac3f7a677 /scratch/sbin/onload_cp_server -K
```

Onload control plane banner:
```console
sh-4.4# dmesg | tail -4
[5358663.764712] [onload] Copyright (c) 2002-2023 Advanced Micro Devices, Inc.
[5358663.768873] [onload] oo_nic_add: ifindex=3088 oo_index=0
[5358678.995953] onload_cp_server[1999926]: Onload Control Plane server   started: id 0, pid 1999926
[5358678.998779] onload_cp_server[1999926]: Accelerating sf0: RX 1 TX 1
```

The sfnt-pingpong from the PoC branch works too.

---

Links:
- https://github.com/Xilinx-CNS/kubernetes-onload/pull/23 -- The originating container ID code to tackle API.
- https://github.com/Xilinx-CNS/kubernetes-onload/pull/48 -- A bold attempt to use `kubectl` instead of the Golang API.