### PR TITLE
SCL-1975: Add missing license headers

### DIFF
--- a/config/manifests/bases/onload-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/onload-operator.clusterserviceversion.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:

--- a/controllers/onload_controller_test.go
+++ b/controllers/onload_controller_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 package controllers
 
 import (


### PR DESCRIPTION
Discovered missing during pre-release checking.