### PR TITLE
ON-14979: Added a simple Github action to run unit tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,13 @@
+on: [push, pull_request]
+
+jobs:
+  ut:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.21.0'
+      - run: make test
+


### PR DESCRIPTION
https://github.com/krishd-amd/kubernetes-onload/actions/runs/6261028520
https://github.com/krishd-amd/kubernetes-onload/actions/runs/6261028520/job/17000252527

A simple action to just run the golang unit tests. In the absence of a jenkins instance, this seems rather simple and easy to get it repeatedly running on commit.