### PR TITLE
Cleanup: Bump kmm version to 1.1.0 in missed files

### DIFF
--- a/ContainerFileNotice
+++ b/ContainerFileNotice
@@ -199,7 +199,7 @@ deviceplugin.Dockerfile:
 |-------------------------------------------------------------+--------------+----------------------------------------------------------------------------------------|
 | github.com/golang/glog, v1.1.2                              | Apache-2.0   | https://github.com/golang/glog/blob/v1.1.2/LICENSE                                     |
 |-------------------------------------------------------------+--------------+----------------------------------------------------------------------------------------|
-| github.com/kubernetes-sigs/kernel-module-management, v1.0.0 | Apache-2.0   | https://github.com/kubernetes-sigs/kernel-module-management/blob/v1.0.0/LICENSE        |
+| github.com/kubernetes-sigs/kernel-module-management, v1.1.0 | Apache-2.0   | https://github.com/kubernetes-sigs/kernel-module-management/blob/v1.1.0/LICENSE        |
 |-------------------------------------------------------------+--------------+----------------------------------------------------------------------------------------|
 | github.com/onsi/ginkgo/v2, v2.11.0                          | MIT          | https://github.com/onsi/ginkgo/blob/v2.11.0/LICENSE                                    |
 |-------------------------------------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -4,4 +4,4 @@ dependencies:
 - type: olm.package
   value:
     packageName: kernel-module-management
-    version: ">=1.0.0"
+    version: ">=1.1.0"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -56,7 +56,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "config", "crd", "bases"),
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com",
-				"kubernetes-sigs", "kernel-module-management@v1.0.0",
+				"kubernetes-sigs", "kernel-module-management@v1.1.0",
 				"config", "crd", "bases"),
 		},
 		ErrorIfCRDPathMissing: true,


### PR DESCRIPTION
Issue noticed with addition of github action for unit tests.

## Testing done
github action on push passed