### PR TITLE
Cleanup: Fix various issues raised by linting

### DIFF
--- a/controllers/onload_controller.go
+++ b/controllers/onload_controller.go
@@ -503,7 +503,7 @@ func (r *OnloadReconciler) handleModuleUpdate(ctx context.Context, onload *onloa
 			}
 		} else if apierrors.IsNotFound(err) {
 			if isUsed {
-				err := fmt.Errorf("Module %s should exist", moduleName)
+				err := fmt.Errorf("module %s should exist", moduleName)
 				return nil, err
 			} else {
 				return nil, nil

--- a/controllers/onload_controller_test.go
+++ b/controllers/onload_controller_test.go
@@ -631,7 +631,7 @@ var _ = Describe("onload controller", func() {
 				Expect(len(onload.Spec.Onload.KernelMappings)).To(Equal(1))
 
 				onload.Spec.Onload.KernelMappings[0].KernelModuleImage = "kernel-image:tag2"
-				k8sClient.Patch(ctx, onload, client.MergeFrom(oldOnload))
+				Expect(k8sClient.Patch(ctx, onload, client.MergeFrom(oldOnload))).Should(Succeed())
 
 				By("re-checking Onload Device Plugin")
 				Eventually(func() bool {

--- a/pkg/control_plane/control_plane.go
+++ b/pkg/control_plane/control_plane.go
@@ -17,7 +17,7 @@ func Configure(
 	// Split the container runtime type from identifier.
 	containerID, found := strings.CutPrefix(containerID, "cri-o://")
 	if !found {
-		return fmt.Errorf("Unsupported container runtime in %s", containerID)
+		return fmt.Errorf("unsupported container runtime in %s", containerID)
 	}
 
 	glog.Info("CRI-O container ID is ", containerID)

--- a/pkg/control_plane/control_plane_test.go
+++ b/pkg/control_plane/control_plane_test.go
@@ -8,10 +8,6 @@ import (
 )
 
 const (
-	mockPodNamespace  = "mockPodNamespace"
-	mockPodName       = "mockPodName"
-	mockContainerName = "mockContainerName"
-
 	mockOnloadCPServerPath = "/mock/sbin/onload_cp_server"
 
 	mockCRIOContainerID       = "cri-o://0123456789abcdef"


### PR DESCRIPTION
## Testing done
Ran `golangci-lint run ./...`, `staticcheck ./...` and `make test`
Only issue raised was by `golangci-lint` which was confiused about new definitions added in 1.21 (`min` and `max` undefined in standard library `slices` package) 

Also did a manual test to verify that the changes to `removeStaleLabels` didn't affect anything