### PR TITLE
ON-14865: Resolve preflight failures and errors

### DIFF
--- a/ContainerFileNotice
+++ b/ContainerFileNotice
@@ -44,7 +44,7 @@ Dockerfile:
 |-------------------------------------------------------------+--------------+---------------------------------------------------------------------------------|
 | github.com/golang/glog, v1.1.2                              | Apache-2.0   | https://github.com/golang/glog/blob/v1.1.2/LICENSE                              |
 |-------------------------------------------------------------+--------------+---------------------------------------------------------------------------------|
-| github.com/kubernetes-sigs/kernel-module-management, v1.0.0 | Apache-2.0   | https://github.com/kubernetes-sigs/kernel-module-management/blob/v1.0.0/LICENSE |
+| github.com/kubernetes-sigs/kernel-module-management, v1.1.0 | Apache-2.0   | https://github.com/kubernetes-sigs/kernel-module-management/blob/v1.1.0/LICENSE |
 |-------------------------------------------------------------+--------------+---------------------------------------------------------------------------------|
 | github.com/onsi/ginkgo/v2, v2.11.0                          | MIT          | https://github.com/onsi/ginkgo/blob/v2.11.0/LICENSE                             |
 |-------------------------------------------------------------+--------------+---------------------------------------------------------------------------------|

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ FROM registry.access.redhat.com/ubi8/ubi-micro:8.8
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/LICENSE /licenses/LICENSE
-USER 65532:65532
+USER 1001
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,8 @@ COPY LICENSE LICENSE
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Use UBI as the base image as suggested by the opdev/preflight certification utility.
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/LICENSE /licenses/LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 
+COPY LICENSE LICENSE
+
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
@@ -31,6 +33,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/LICENSE /licenses/LICENSE
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} . --network="host"
+	docker build -t ${IMG} --network="host" .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -145,7 +145,7 @@ worker-build: ## Build Onload worker app.
 
 .PHONY: device-plugin-docker-build
 device-plugin-docker-build: test ## Build docker image with the manager.
-	docker build -t ${DEVICE_IMG} -f deviceplugin.Dockerfile --network="host"
+	docker build -t ${DEVICE_IMG} -f deviceplugin.Dockerfile --network="host" .
 
 .PHONY: device-plugin-docker-push
 device-plugin-docker-push: test ## Push docker image to the registry.

--- a/deviceplugin.Dockerfile
+++ b/deviceplugin.Dockerfile
@@ -22,7 +22,7 @@ COPY LICENSE /app/LICENSE
 RUN CGO_ENABLED=0 make device-plugin-build worker-build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
-RUN microdnf install lshw
+RUN microdnf install -y lshw-B.02.19.2 && microdnf clean all
 COPY --from=builder /app/bin/onload-device-plugin /app/bin/onload-worker /usr/bin/
 COPY --from=builder /app/LICENSE /licenses/LICENSE
 CMD ["/usr/bin/onload-device-plugin"]

--- a/deviceplugin.Dockerfile
+++ b/deviceplugin.Dockerfile
@@ -25,4 +25,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 RUN microdnf install -y lshw-B.02.19.2 && microdnf clean all
 COPY --from=builder /app/bin/onload-device-plugin /app/bin/onload-worker /usr/bin/
 COPY --from=builder /app/LICENSE /licenses/LICENSE
+USER 1001
+
 CMD ["/usr/bin/onload-device-plugin"]

--- a/deviceplugin.Dockerfile
+++ b/deviceplugin.Dockerfile
@@ -17,9 +17,12 @@ COPY pkg/deviceplugin /app/pkg/deviceplugin
 COPY cmd/deviceplugin /app/cmd/deviceplugin
 COPY cmd/worker /app/cmd/worker
 
+COPY LICENSE /app/LICENSE
+
 RUN CGO_ENABLED=0 make device-plugin-build worker-build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 RUN microdnf install lshw
 COPY --from=builder /app/bin/onload-device-plugin /app/bin/onload-worker /usr/bin/
+COPY --from=builder /app/LICENSE /licenses/LICENSE
 CMD ["/usr/bin/onload-device-plugin"]


### PR DESCRIPTION
This PR addresses the `HasLicense` and `RunAsNonRoot` failures for the Device Plugin image and `HasLicense`, `HasRequiredLabel`, `BasedOnUbi` failures and the `HasNoProhibitedPackages` error for the controller manager image.

Also, it contains a tiny ContainerFileNotice fix since it's a "cleanup" PR.

Testing:

- Tested accelerated net IO in the cluster with `sfnt-pingpong`.
- Tested with the `docker://quay.io/opdev/preflight:1.7.0` utility.

Also captured some hands-on notes in Confluence: https://confluence.xilinx.com/display/~iteterev/gh+act+-+Jump+start+Guide.