### PR TITLE
ON-15022: Add onload-module Dockerfile and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,3 +300,7 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+.PHONY: onload-module-dtk
+onload-module-dtk:
+	$(MAKE) -C build/onload-module onload-module-dtk

--- a/build/onload-module/Makefile
+++ b/build/onload-module/Makefile
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+.PHONY: all onload-module-dtk dtk_vars onload_vars
+
+OCP_VERSION :=
+DTK_AUTO ?= $$(oc adm release info $(OCP_VERSION) --image-for=driver-toolkit)
+KERNEL_VERSION ?= $$(./dtk-release-vars --kernel-version $(DTK_AUTO))
+
+ONLOAD_SOURCE_IMAGE_REPO ?= onload-source
+ONLOAD_SOURCE_IMAGE_TAG ?= latest
+ONLOAD_SOURCE ?= $(ONLOAD_SOURCE_IMAGE_REPO):$(ONLOAD_SOURCE_IMAGE_TAG)
+ONLOAD_VERSION ?= $$(./onload-source-vars --onload-version $(ONLOAD_SOURCE))
+
+ONLOAD_MODULE_IMAGE_REPO ?= onload-module
+ONLOAD_MODULE ?= $(ONLOAD_MODULE_IMAGE_REPO):$(ONLOAD_VERSION)-$(KERNEL_VERSION)
+
+dtk_vars:
+	@echo DTK_AUTO=$(DTK_AUTO)
+	@echo KERNEL_VERSION=$(KERNEL_VERSION)
+
+onload_vars:
+	@echo ONLOAD_VERSION=$(ONLOAD_VERSION)
+	@echo ONLOAD_MODULE=$(ONLOAD_MODULE)
+
+all: onload-module-dtk
+
+onload-module-dtk: dtk_vars onload_vars
+	docker build \
+		-t $(ONLOAD_MODULE) \
+		--build-arg DTK_AUTO=$(DTK_AUTO) \
+		--build-arg ONLOAD_SOURCE=$(ONLOAD_SOURCE) \
+		--build-arg KERNEL_FULL_VERSION=$(KERNEL_VERSION) \
+		../../config/samples/onload-module/

--- a/build/onload-module/README.md
+++ b/build/onload-module/README.md
@@ -1,0 +1,37 @@
+# `onload-module` Container Image
+
+The container image must be built using the:
+
+* exact kernel version headers of target node(s), and the
+* exact Onload version/revision deployed with the Onload Operator and/or Onload Device Plugin.
+
+## Building within the cluster
+
+This directory is not relevant to building within the cluster.
+
+KMM can build `onload-module` container images automatically in-cluster for use by Kubernetes Onload. In-cluster, KMM selects the `DTK_AUTO` container image by itself. Only a `onload-source` container image and `Dockerfile` therefore needs to be supplied to KMM (typically via the Onload Operator).
+
+KMM can also perform builds against non-running RHCOS though the use of its `PreflightValidation` CR.
+
+## Building outside the cluster for OpenShift
+
+When building outside the cluster, dependencies and their versioning are gathered independently of KMM. The [Makefile](./Makefile) attempts to derive them for you:
+
+```sh
+make onload-module OCP_VERSION=4.12.12 ONLOAD_SOURCE=ghcr.io/xilinx-cns/onload-source:8.1.1
+```
+
+The above requires:
+
+* `make`
+* `jq`
+* `docker` or `podman-docker`
+* `oc`
+
+The `OCP_VERSION` variable is used to select the Red Hat Driver Toolkit (DTK) image corresponding to your release of OCP. Each release of OCP has a corresponding Red Hat CoreOS (RHCOS) kernel version associated with it, and those kernel headers are embedded in the DTK image.
+
+Alternatively, to avoid using `oc` command, supply the image directly with `make ... DTK_AUTO=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...`. To find your DTK image digest, use `oc adm release info --image-for=driver-toolkit` within the cluster or refer to your OCP client's `release.txt`.
+
+---
+
+(c) Copyright 2023 Advanced Micro Devices, Inc.

--- a/build/onload-module/dtk-release-vars
+++ b/build/onload-module/dtk-release-vars
@@ -1,0 +1,16 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+container_id=$(docker create "$2")
+release_json=$(docker cp "$container_id:/etc/driver-toolkit-release.json" - | tar x -O)
+docker rm "$container_id" >/dev/null
+
+case "$1" in
+  --env)
+    echo "$release_json" | jq -r 'to_entries | .[] | .key + "=" + (.value | @sh)' ;;
+  --kernel-version)
+    echo "$release_json" | jq -r .KERNEL_VERSION ;;
+  --json|*)
+    echo "$release_json" ;;
+esac

--- a/build/onload-module/onload-source-vars
+++ b/build/onload-module/onload-source-vars
@@ -1,0 +1,12 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+if ! docker inspect "$2" >/dev/null 2>&1; then
+  docker pull "$2" >/dev/null
+fi
+
+case "$1" in
+  --onload-version)
+    docker inspect -f '{{.Config.Labels.version}}' "$2"
+esac

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -3,4 +3,5 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - onload_v1alpha1_onload.yaml
+- onload-module
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/onload-module/ContainerFileNotice
+++ b/config/samples/onload-module/ContainerFileNotice
@@ -1,0 +1,48 @@
+NOTICE - BY INVOKING THIS SCRIPT AND USING THE SOFTWARE INSTALLED BY THE
+SCRIPT, YOU AGREE ON BEHALF OF YOURSELF AND YOUR EMPLOYER (IF APPLICABLE) TO BE
+BOUND TO THE LICENSE AGREEMENTS APPLICABLE TO THE PACKAGES IDENTIFIED BELOW
+THAT YOU INSTALL BY RUNNING THE SCRIPT. YOU UNDERSTAND THAT THE INSTALLATION OF
+THE PACKAGES LISTED BELOW MAY ALSO RESULT IN THE INSTALLATION ON YOUR SYSTEM OF
+ADDITIONAL PACKAGES NOT LISTED BELOW IN ORDER TO OPERATE (EACH, A
+‘DEPENDENCY’). ADVANCED MICRO DEVICES, INC., ON BEHALF OF ITSELF AND ITS
+SUBSIDIARIES AND AFFILIATES, DOES NOT GRANT TO YOU ANY RIGHTS OR LICENSES TO
+ANY SUCH DEPENDENCY. THE SCRIPT ITSELF IS LICENSED TO YOU SUBJECT TO THE
+FOLLOWING TERMS:
+
+Copyright © 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+
+This file is licensed under the following license terms (MIT):
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+This file pulls in the following packages subject to the licenses identified
+below:
+
+| Package, Version                 | License      | URL                                                                                    |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|
+| Red Hat Universal Base Image, 9  | UBI EULA     | https://www.redhat.com/agreements                                                      |
+|                                  | + Various    |                                                                                        |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|
+| Red Hat Driver Toolkit, Various  | Red Hat EULA | https://www.redhat.com/agreements                                                      |
+|                                  | + Various    |                                                                                        |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|
+| AMD Onload, Various              | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/master/src/onload/distfiles/LICENSE          |
+|                                  | AND          |                                                                                        |
+|                                  | BSD-2-Clause |                                                                                        |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/config/samples/onload-module/Dockerfile
+++ b/config/samples/onload-module/Dockerfile
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+# hadolint global ignore=DL3006,DL3059,DL3040,DL3041
+ARG DTK_AUTO
+ARG ONLOAD_SOURCE=onload-source
+ARG UBI_BASE=registry.access.redhat.com/ubi9/ubi-minimal:9.2
+
+
+FROM $ONLOAD_SOURCE as onload-source
+
+
+FROM $DTK_AUTO as builder
+ARG ONLOAD_BUILD_PARAMS
+ARG KERNEL_FULL_VERSION
+COPY --from=onload-source / /opt/onload
+WORKDIR /opt/onload
+ENV i_prefix=/opt
+RUN scripts/onload_build --kernel --kernelver $KERNEL_FULL_VERSION $ONLOAD_BUILD_PARAMS
+RUN scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERSION
+RUN make -j8 -C src/driver/linux_net CONFIG_SFC_VDPA= CONFIG_SFC_MTD= KVER=$KERNEL_FULL_VERSION
+RUN /sbin/depmod -b /opt $KERNEL_FULL_VERSION
+
+
+# ON-15418: Consider reducing deps
+FROM $UBI_BASE
+ARG KERNEL_FULL_VERSION
+RUN microdnf install -y kmod && dnf clean all
+COPY --from=builder /opt/lib/modules/ /opt/lib/modules/
+COPY --from=builder /build/onload/src/driver/linux_net/drivers/net/ethernet/sfc/sfc*.ko /opt/lib/modules/$KERNEL_FULL_VERSION/
+COPY --from=builder /build/onload/src/driver/linux_net/drivers/net/ethernet/sfc/sfc_driverlink.ko /opt/lib/modules/$KERNEL_FULL_VERSION/

--- a/config/samples/onload-module/dtk-only.Dockerfile
+++ b/config/samples/onload-module/dtk-only.Dockerfile
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+# hadolint global ignore=DL3006
+ARG DTK_AUTO
+ARG ONLOAD_SOURCE=onload-source
+
+
+FROM $ONLOAD_SOURCE as onload-source
+
+
+FROM $DTK_AUTO
+ARG ONLOAD_BUILD_PARAMS
+ARG KERNEL_FULL_VERSION
+COPY --from=onload-source / /opt/onload
+WORKDIR /opt/onload
+ENV i_prefix=/opt
+RUN scripts/onload_build --kernel --kernelver $KERNEL_FULL_VERSION $ONLOAD_BUILD_PARAMS && \
+    scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERSION && \
+    make -j8 -C src/driver/linux_net CONFIG_SFC_VDPA= CONFIG_SFC_MTD= KVER=$KERNEL_FULL_VERSION && \
+    /sbin/depmod -b /opt $KERNEL_FULL_VERSION

--- a/config/samples/onload-module/kustomization.yaml
+++ b/config/samples/onload-module/kustomization.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- name: onload-module-dockerfile
+  files:
+  - dockerfile=Dockerfile
+- name: onload-module-dtk-only-dockerfile
+  files:
+  - dockerfile=dtk-only.Dockerfile

--- a/config/samples/onload-module/mkdist-direct.Dockerfile
+++ b/config/samples/onload-module/mkdist-direct.Dockerfile
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+# hadolint global ignore=DL3006,DL3020,DL3059,DL3040,DL3041
+ARG DTK_AUTO
+ARG UBI_BASE=registry.access.redhat.com/ubi9/ubi-minimal:9.2
+
+
+FROM $DTK_AUTO as builder
+ARG ONLOAD_BUILD_PARAMS
+ARG ONLOAD_LOCATION
+ARG KERNEL_FULL_VERSION
+
+WORKDIR /build/
+ADD $ONLOAD_LOCATION onload.tar.gz
+RUN mkdir -p /build/onload
+RUN tar xzf onload.tar.gz -C /build/onload --strip-components=1
+WORKDIR /build/onload/
+
+ENV i_prefix=/opt
+RUN scripts/onload_build --kernel --kernelver $KERNEL_FULL_VERSION $ONLOAD_BUILD_PARAMS && \
+    scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERSION && \
+    make -j8 -C src/driver/linux_net CONFIG_SFC_VDPA= CONFIG_SFC_MTD= KVER=$KERNEL_FULL_VERSION && \
+    /sbin/depmod -b /opt $KERNEL_FULL_VERSION
+
+
+FROM $UBI_BASE
+ARG KERNEL_VERSION
+RUN microdnf install -y kmod && dnf clean all
+COPY --from=builder /opt/lib/modules/ /opt/lib/modules/


### PR DESCRIPTION
Lays groundwork for ON-15375 and removes last dependency on PoC.

Changes:
* Copied `Dockerfile` from PoC. Updated primary method to build from `onload-source` container image, UBI 9, and some further minimising of dependencies. The `dtk-only.Dockerfile` variant removes dependency on UBI to ease use in restricted networks.
* Added `Makefile` with helper (optionally autonomous) scripts for one-liner `docker build`.

Located in this repo due to RedHat-specific DTK dependency. Can be reviewed at later date wrt other use cases.
Full cluster + kustomize tests still ToDo.