### PR TITLE
ON-15417: Fix Onload and SFC Dockerfile to load their deps at runtime

### DIFF
--- a/config/samples/onload-module/Dockerfile
+++ b/config/samples/onload-module/Dockerfile
@@ -14,14 +14,15 @@ ARG ONLOAD_BUILD_PARAMS
 ARG KERNEL_FULL_VERSION
 COPY --from=onload-source / /opt/onload
 WORKDIR /opt/onload
-ENV i_prefix=/opt
 RUN scripts/onload_build --kernel --kernelver $KERNEL_FULL_VERSION $ONLOAD_BUILD_PARAMS
 RUN scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERSION
-RUN /sbin/depmod -b /opt $KERNEL_FULL_VERSION
+RUN depmod $KERNEL_FULL_VERSION
 
 
 # ON-15418: Consider reducing deps
 FROM $UBI_BASE
 ARG KERNEL_FULL_VERSION
 RUN microdnf install -y kmod && microdnf clean all
-COPY --from=builder /opt/lib/modules/ /opt/lib/modules/
+COPY --from=builder /lib/modules/$KERNEL_FULL_VERSION/modules* /opt/lib/modules/$KERNEL_FULL_VERSION/
+COPY --from=builder /lib/modules/$KERNEL_FULL_VERSION/extra /opt/lib/modules/$KERNEL_FULL_VERSION/extra
+RUN ln -s /lib/modules/$KERNEL_FULL_VERSION/kernel /opt/lib/modules/$KERNEL_FULL_VERSION/kernel

--- a/config/samples/onload-module/dtk-only.Dockerfile
+++ b/config/samples/onload-module/dtk-only.Dockerfile
@@ -13,7 +13,12 @@ ARG ONLOAD_BUILD_PARAMS
 ARG KERNEL_FULL_VERSION
 COPY --from=onload-source / /opt/onload
 WORKDIR /opt/onload
-ENV i_prefix=/opt
-RUN scripts/onload_build --kernel --kernelver $KERNEL_FULL_VERSION $ONLOAD_BUILD_PARAMS && \
-    scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERSION && \
-    /sbin/depmod -b /opt $KERNEL_FULL_VERSION
+RUN scripts/onload_build --kernel --kernelver $KERNEL_FULL_VERSION $ONLOAD_BUILD_PARAMS
+RUN scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERSION
+RUN depmod $KERNEL_FULL_VERSION
+
+
+RUN mkdir -p /opt/lib/modules/$KERNEL_FULL_VERSION
+RUN cp -v /lib/modules/$KERNEL_FULL_VERSION/modules* /opt/lib/modules/$KERNEL_FULL_VERSION/
+RUN cp -rv /lib/modules/$KERNEL_FULL_VERSION/extra /opt/lib/modules/$KERNEL_FULL_VERSION/extra
+RUN ln -s /lib/modules/$KERNEL_FULL_VERSION/kernel /opt/lib/modules/$KERNEL_FULL_VERSION/kernel


### PR DESCRIPTION
Fix Onload Dockerfile so that depmod could compute the dependencies on the built kernel modules and modprobe could load them at runtime.

Thanks: Yevgeny Shnaidman and Quentin Barrand

---

The SFC module gets loaded if built with the MTD and VDPA support:
```
$ oc get pod; oc get module
NAME                                          READY   STATUS    RESTARTS            AGE
onload-sample-onload-device-plugin-ds-8wt4j   2/2     Running   3 (<invalid> ago)   2m58s
onload-sample-onload-device-plugin-ds-k8fvp   2/2     Running   3 (5s ago)          2m58s
onload-sample-onload-module-s7wf9-cmbx7       1/1     Running   0                   2m59s
onload-sample-onload-module-s7wf9-gbrpn       1/1     Running   0                   2m58s
onload-sample-sfc-module-nsz44-4m2ht          1/1     Running   0                   2m58s
onload-sample-sfc-module-nsz44-ck62x          1/1     Running   0                   2m58s
NAME                          AGE
onload-sample-onload-module   2m3s
onload-sample-sfc-module      2m3s

```