### PR TITLE
ON-15417: Optimise dtk-only.Dockerfile

### DIFF
--- a/config/samples/onload-module/dtk-only.Dockerfile
+++ b/config/samples/onload-module/dtk-only.Dockerfile
@@ -18,7 +18,5 @@ RUN scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERS
 RUN depmod $KERNEL_FULL_VERSION
 
 
-RUN mkdir -p /opt/lib/modules/$KERNEL_FULL_VERSION
-RUN cp -v /lib/modules/$KERNEL_FULL_VERSION/modules* /opt/lib/modules/$KERNEL_FULL_VERSION/
-RUN cp -rv /lib/modules/$KERNEL_FULL_VERSION/extra /opt/lib/modules/$KERNEL_FULL_VERSION/extra
-RUN ln -s /lib/modules/$KERNEL_FULL_VERSION/kernel /opt/lib/modules/$KERNEL_FULL_VERSION/kernel
+RUN mkdir -p /opt/lib/modules
+RUN ln -s /lib/modules/$KERNEL_FULL_VERSION /opt/lib/modules/$KERNEL_FULL_VERSION


### PR DESCRIPTION
Suggested-by: Peter Colledge <peter.colledge@amd.com>

---

Tested in a virtualised OpenShift cluster.

I patched Makefile to use the patched Dockerfile:
```diff
diff --git a/build/onload-module/Makefile b/build/onload-module/Makefile
index c0edfdf..5edd5d0 100644
--- a/build/onload-module/Makefile
+++ b/build/onload-module/Makefile
@@ -30,4 +30,4 @@ onload-module-dtk: dtk_vars onload_vars
                --build-arg DTK_AUTO=$(DTK_AUTO) \
                --build-arg ONLOAD_SOURCE=$(ONLOAD_SOURCE) \
                --build-arg KERNEL_FULL_VERSION=$(KERNEL_VERSION) \
-               ../../config/samples/onload-module/
+               ../../config/samples/onload-module/ -f ../../config/samples/onload-module/dtk-only.Dockerfile
```

Then:
```text
make onload-module-dtk ONLOAD_SOURCE_IMAGE_REPO=... ONLOAD_SOURCE_IMAGE_TAG=... ONLOAD_MODULE_IMAGE_REPO=...
docker push ...
```

And deployed Onload CR with `sfc` in the cluster.