### PR TITLE
ON-15311: Add script to generate configmap from profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,55 @@ There are two key fields in the above example CR:
 
 No further modifications are required to enable Onloaded applications.
 
+### Using Onload profiles
+
+If you want to run your onloaded application with a runtime profile we suggest
+using a ConfigMap to set the environment variables in the pod. We have included
+and example definition for the latency profile in `config/samples/profiles`
+directory. This can be applied as so:
+```text
+oc apply -k config/samples/profiles
+```
+which creates a new ConfigMap called `onload-latency-profile` in the current
+namespace.
+
+Then to use this in you pod, add the following to the container spec in your pod
+definition:
+
+```diff
+diff --git a/testpod.yaml b/testpod.yaml
+index 5259d67..ced3b2a 100644
+--- a/testpod.yaml
++++ b/testpod.yaml
+@@ -16,6 +16,9 @@ spec:
+     imagePullPolicy: Always
+     command:
+     - /test
++    envFrom:
++      - configMapRef:
++          name: onload-latency-profile
+     resources:
+       limits:
+         amd.com/onload: 1
+```
+
+#### Converting an existing profile
+If you have an existing profile defined as a `.opf` file you can generate a new
+ConfigMap definition from this using the `./scripts/profile_to_configmap.sh`
+script.
+
+`profile_to_configmap.sh` takes in a comma separated list of profiles and will
+output the text definition of the ConfigMap which can be saved into a file, or
+sent straight to the cluster. To apply the generated ConfigMap straight away
+run:
+```text
+./profile_to_configmap.sh -p /path/to/profile.opf | oc apply -f -
+```
+
+Currently the script produces ConfigMaps with a fixed naming structure,
+for example if you want to create a ConfigMap from a profile called
+`name.opf` the generated name will be `onload-name-profile`.
+
 ---
 
 Copyright (c) 2023 Advanced Micro Devices, Inc.

--- a/config/samples/profiles/kustomization.yaml
+++ b/config/samples/profiles/kustomization.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- latency.yaml

--- a/config/samples/profiles/latency.yaml
+++ b/config/samples/profiles/latency.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: onload-latency-profile
+data:
+  # OpenOnload low latency profile.
+
+  # Enable polling / spinning.  When the application makes a blocking call
+  # such as recv() or poll(), this causes Onload to busy wait for up to 100ms
+  # before blocking.
+  #
+  EF_POLL_USEC: "100000"
+
+  # Disable FASTSTART when connection is new or has been idle for a while.
+  # The additional acks it causes add latency on the receive path.
+  EF_TCP_FASTSTART_INIT: "0"
+  EF_TCP_FASTSTART_IDLE: "0"
+
+  # Use a large initial congestion window so that the slow-start algorithm
+  # doesn't cause delays.  We don't enable this by default because it breaks
+  # the TCP specs, and could cause congestion in your network.  Uncomment if
+  # you think you need this.
+  #
+  # EF_TCP_INITIAL_CWND:"100000"
+
+  # When TCP_NODELAY is used, always kick packets out immediately.  This is
+  # not enabled by default because most apps benefit from the default
+  # behaviour.
+  #
+  EF_NONAGLE_INFLIGHT_MAX: "65535"

--- a/scripts/profiles/profile_to_configmap.sh
+++ b/scripts/profiles/profile_to_configmap.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+me=$(basename "$0")
+bin=$(cd "$(dirname "$0")" && /bin/pwd)
+
+
+err()	{ echo >&2 "$*"; }
+log()	{ err  "$me: $*"; }
+vlog()	{ $verbose && log "$*"; }
+fail()	{ log "$*"; exit 1; }
+rawecho() { echo -E "x$*" | sed 's/^x//'; }
+prefix()  { sed "s/^/$me: /"; }
+
+sfc_usage() {
+  err
+  err "usage:"
+  err "  $me [options]"
+  err
+  err "options:"
+  err "  -p,--profile=<profile> -- comma sep list of config profile(s)"
+  err "  -h --help              -- this help message"
+  err
+  exit 1
+}
+
+onload_set() {
+  if [ -z "$2" ]; then
+    # it's not in onload_set x y form - try onload_set x=y
+    VAR=$(echo "$1" | cut -f1 -d=)
+    VAL=$(echo "$1" | cut -f2 -d=)
+  else
+    VAR="$1"
+    VAL="$2"
+  fi
+  echo "  $VAR: \"$VAL\""
+}
+
+onload_import() {
+  # Called below to import a profile.  May also be called by config scripts
+  # and profile scripts to import another profile.
+  local profile="$1"
+  local pf1="$HOME/.openonload/profiles/$profile.opf"
+  local pf3="$profile"
+  # *.opf-fragment files are searched only for secondary imports, i.e. use of
+  # onload_import within another profile. This is to prevent fragments being
+  # accidentally used as full-fledged profiles by themselves
+  local pf_frag1="$HOME/.openonload/profiles/$profile.opf-fragment"
+  local pf="$pf1"
+  $toplevelimport || [ -f "$pf" ] || pf="$pf_frag1"
+  for dir in $profile_d; do
+    local pf2="$dir/$profile.opf"
+    [ -f "$pf" ] || pf="$pf2"
+    local pf_frag2="$dir/$profile.opf-fragment"
+    $toplevelimport || [ -f "$pf" ] || pf="$pf_frag2"
+  done
+  [ -f "$pf" ] || pf="$pf3"
+  if ! [ -f "$pf" ]; then
+    log "ERROR: Cannot find profile '$profile'"
+    log "I looked in these places:"
+    log "  $pf1"
+    $toplevelimport || log "  $pf_frag1"
+    for dir in $profile_d; do
+      local pf2="$dir/$profile.opf"
+      log "  $pf2"
+      local pf_frag2="$dir/$profile.opf-fragment"
+      $toplevelimport || log "  $pf_frag2"
+    done
+    log "  $pf3"
+    exit 3
+  fi
+  toplevelimport=false
+  vlog "onload_import: $profile ($pf)"
+  # Source profile, with $@ representing the application and its options
+  shift
+  # shellcheck disable=SC1090
+  . "$pf"
+  vlog "onload_import-done: $profile"
+}
+
+######################################################################
+# main()
+
+if [ -x "$bin/mmaketool" ]; then
+  profile_d="$bin/onload_profiles"
+else
+  profile_d=/usr/libexec/onload/profiles
+fi
+
+profiles=
+verbose=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --profile=*)
+	onload_args="$onload_args $1"
+	profile="${1#--profile=}"
+	[ -n "$profile" ] || sfc_usage
+	profiles="$profiles ${profile//,/ }"
+	;;
+    --profile|-p)
+	onload_args="$onload_args $1 $2"
+	shift
+	profile="$1"
+	[ -n "$profile" ] || sfc_usage
+	profiles="$profiles ${profile//,/ }"
+	;;
+    -*)	sfc_usage
+	;;
+  esac
+  shift
+done
+
+[ $# = 0 ] && [ -z "$profiles" ] && sfc_usage
+
+for profile in $profiles; do
+  profile_d="$profile_d $(dirname "$profile")"
+done
+
+for profile in $profiles; do
+  echo "apiVersion: v1"
+  echo "kind: ConfigMap"
+  echo "metadata:"
+  echo "  name: onload-$(basename "$profile" .opf)-profile"
+  echo "data:"
+  onload_import "$profile" "$@"
+  echo "---"
+done


### PR DESCRIPTION
Adds a new script `process_profile.sh` which is essentially a stripped down version of the `onload` script that only includes the logic used to process the profiles. The new script has the same syntax as the original onload version, but now instead of setting environment variables it will output the yaml text definition of a ConfigMap which can be used to set environment variables in a user's pod.

Currently the script produces ConfigMaps with a fixed naming structure, for example if you want to create a ConfigMap from a profile called `name.opf` the generated name will be `onload-name-profile`.

If you want to apply the generate ConfigMap straight away, then you can simply run:
`./process_profile.sh -p /path/to/profile.opf | oc apply -f -`

This patch also includes an example latency profile in config/profiles

## Testing done

Verified the generated ConfigMap against the known good examples from `v3.0.0-pre`

Also `shellcheck` has no complaints/warnings from the new file