### PR TITLE
ON-15438: Document sfptpd deployment using Kustomize

### DIFF
--- a/config/samples/sfptpd/README.md
+++ b/config/samples/sfptpd/README.md
@@ -1,0 +1,61 @@
+
+# Solarflare Enhanced PTP Daemon (sfptpd)
+
+To run `sfptpd` in a Kubernetes cluster, deploy the `sfptpd` privileged
+container to all nodes receiving PTP signal and
+[disable the node's existing time services](#disable-default-time-source).
+
+This directory provides a Kustomize formatted base
+([DaemonSet](base/daemonset.yaml)) and example overlays.
+
+(The Onload Operator does not presently manage `sfptpd`; please refer to
+Release Notes for details on expressing interest in this feature.)
+
+## Quickstart
+
+The example Kustomize overlay
+[overlays/example-bond0/kustomization.yaml](overlays/example-bond0/kustomization.yaml)
+would deploy the following to a namespace called `sfptpd`:
+
+1. A DaemonSet deploying the `sfptpd` container to worker nodes labelled
+   `node-role.kubernetes.io/ptp`.
+2. A [sfptpd.cfg](overlays/example-bond0/sfptpd.cfg) config file specifying
+   the pod's PTP ethernet interface name as `bond0`. (A bond is not required.)
+
+To use in your own cluster, make a copy and apply:
+
+```sh
+cp -r overlays/example-bond0 overlays/my-cluster
+$EDITOR overlays/my-cluster/kustomization.yaml
+$EDITOR overlays/my-cluster/sfptpd.cfg
+kubectl label nodes <your-ptp-node> node-role.kubernetes.io/ptp=
+kubectl apply -k overlays/my-cluster
+```
+
+Ensure you have also disabled the node's existing time services.
+
+## Disable default time source
+
+A node must have one time source only. sfptpd should replace services such
+as `ntpd` and `chronyd` if they manage the local host's time.
+
+If you are running OpenShift, follow the [Redhat documentation on disabling chronyd.service](https://docs.openshift.com/container-platform/4.10/post_installation_configuration/machine-configuration-tasks.html#cnf-disable-chronyd_post-install-machine-configuration-tasks).
+Ensure the resulting MachineConfigPool exactly selects the nodes specified
+above; if using the Quickstart's node label of `node-role.kubernetes.io/ptp`,
+use a NodeSelector matching this label.
+
+## Source Code & Documentation
+
+Container images with compiled binaries are provided. To build the container
+afresh, refer to
+[sfptpd on GitHub](https://github.com/Xilinx-CNS/sfptpd/#building-a-container-image).
+
+Example config (.cfg) files are available from
+[sfptpd on GitHub](https://github.com/Xilinx-CNS/sfptpd/tree/master/config).
+
+Full documentation is available in the
+[Enhanced PTP User Guide](https://docs.xilinx.com/r/en-US/ug1602-ptp-user)
+
+## Footnotes
+
+(c) Copyright 2023 Advanced Micro Devices, Inc.

--- a/config/samples/sfptpd/base/daemonset.yaml
+++ b/config/samples/sfptpd/base/daemonset.yaml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+# (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sfptpd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sfptpd
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - privileged
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sfptpd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sfptpd
+subjects:
+- kind: ServiceAccount
+  name: sfptpd
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sfptpd
+spec:
+  selector:
+    matchLabels:
+      name: sfptpd
+  template:
+    metadata:
+      labels:
+        name: sfptpd
+    spec:
+      hostNetwork: true
+      serviceAccountName: sfptpd
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      containers:
+      - image: onload/sfptpd:latest
+        name: sfptpd
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: etc-sfptpd
+          mountPath: "/etc/sfptpd"
+        securityContext:
+          privileged: true
+        args: ["-f", "/etc/sfptpd/sfptpd.cfg"]
+      volumes:
+      - name: etc-sfptpd
+        configMap:
+          name: sfptpd-config

--- a/config/samples/sfptpd/base/kustomization.yaml
+++ b/config/samples/sfptpd/base/kustomization.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- daemonset.yaml

--- a/config/samples/sfptpd/overlays/example-bond0/kustomization.yaml
+++ b/config/samples/sfptpd/overlays/example-bond0/kustomization.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- ../../base
+
+configMapGenerator:
+- name: sfptpd-config
+  files:
+  - sfptpd.cfg
+
+# Corresponds to namespace.yaml
+namespace: sfptpd
+
+# Latest stable
+images:
+- name: onload/sfptpd
+  newName: docker.io/onload/sfptpd
+  newTag: 3.7.1.1000
+
+# Assign sfptpd daemon to a node with label `node-role.kubernetes.io/ptp`
+labels:
+- pairs:
+    node-role.kubernetes.io/ptp: ""
+  fields:
+  - path: spec/template/spec/nodeSelector
+    kind: DaemonSet
+    create: true

--- a/config/samples/sfptpd/overlays/example-bond0/namespace.yaml
+++ b/config/samples/sfptpd/overlays/example-bond0/namespace.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sfptpd

--- a/config/samples/sfptpd/overlays/example-bond0/sfptpd.cfg
+++ b/config/samples/sfptpd/overlays/example-bond0/sfptpd.cfg
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+[general]
+sync_module ptp ptp1
+
+# Log to stdout/stderr. The recommended way to deploy would be only logging
+# the message log, to stderr, and placing an adapter program in the pod to
+# process RT JSON stats and make them available to a time series database.
+message_log stderr
+stats_log stdout
+
+[ptp1]
+ptp_domain 0
+interface bond0

--- a/config/samples/sfptpd/overlays/link-local-peer-bond0/kustomization.yaml
+++ b/config/samples/sfptpd/overlays/link-local-peer-bond0/kustomization.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- ../../base
+
+configMapGenerator:
+- name: sfptpd-config
+  files:
+  - sfptpd.cfg
+
+namespace: sfptpd
+
+images:
+- name: onload/sfptpd
+  newName: docker.io/onload/sfptpd
+  newTag: master-dev

--- a/config/samples/sfptpd/overlays/link-local-peer-bond0/namespace.yaml
+++ b/config/samples/sfptpd/overlays/link-local-peer-bond0/namespace.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sfptpd

--- a/config/samples/sfptpd/overlays/link-local-peer-bond0/sfptpd.cfg
+++ b/config/samples/sfptpd/overlays/link-local-peer-bond0/sfptpd.cfg
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+[general]
+sync_module freerun fr1
+sync_module ptp ptp1
+
+message_log stderr
+stats_log stdout
+
+non_solarflare_nics off
+
+[fr1]
+interface bond0
+
+[ptp1]
+interface bond0
+ptp_mode master
+ptp_domain 0
+transport ipv4

--- a/config/samples/sfptpd/overlays/system-clock/kustomization.yaml
+++ b/config/samples/sfptpd/overlays/system-clock/kustomization.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- ../../base
+
+configMapGenerator:
+- name: sfptpd-config
+  files:
+  - sfptpd.cfg
+
+namespace: sfptpd
+
+images:
+- name: onload/sfptpd
+  newName: docker.io/onload/sfptpd
+  newTag: master-dev

--- a/config/samples/sfptpd/overlays/system-clock/namespace.yaml
+++ b/config/samples/sfptpd/overlays/system-clock/namespace.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sfptpd

--- a/config/samples/sfptpd/overlays/system-clock/sfptpd.cfg
+++ b/config/samples/sfptpd/overlays/system-clock/sfptpd.cfg
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+# Standalone smoke test that does not set system clock.
+# For testing deployment only in environments without specialised hardware.
+
+[general]
+sync_module freerun fr1
+
+message_log stderr
+stats_log stdout
+trace_level 3
+
+clock_readonly system
+non_xilinx_nics off
+
+[fr1]
+interface system


### PR DESCRIPTION
Uses pure Kustomize to enable user environment-specific customisation and enable us to provide further use case and version updates without modifying core config.

Smoke test overlay works in minikube.

In review until:
- [ ] in-cluster tests complete

Outputs:
```sh
kubernetes-onload/config/samples/sfptpd$ kubectl kustomize overlays/example-sf0/
```

```yaml
apiVersion: v1
kind: Namespace
metadata:
  labels:
    node-role.kubernetes.io/ptp: ""
  name: sfptpd
---
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    node-role.kubernetes.io/ptp: ""
  name: sfptpd
  namespace: sfptpd
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  labels:
    node-role.kubernetes.io/ptp: ""
  name: sfptpd
  namespace: sfptpd
rules:
- apiGroups:
  - security.openshift.io
  resourceNames:
  - privileged
  resources:
  - securitycontextconstraints
  verbs:
  - use
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  labels:
    node-role.kubernetes.io/ptp: ""
  name: sfptpd
  namespace: sfptpd
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: sfptpd
subjects:
- kind: ServiceAccount
  name: sfptpd
  namespace: sfptpd
---
apiVersion: v1
data:
  sfptpd.cfg: |
    [general]
    sync_module ptp ptp1

    # Log to stdout/stderr. The recommended way to deploy would be only logging
    # the message log, to stderr, and placing an adapter program in the pod to
    # process RT JSON stats and make them available to a time series database.
    message_log stderr
    stats_log stdout

    [ptp1]
    ptp_domain 0
    interface sf0
kind: ConfigMap
metadata:
  labels:
    node-role.kubernetes.io/ptp: ""
  name: sfptpd-config-c65fbfbchb
  namespace: sfptpd
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    node-role.kubernetes.io/ptp: ""
  name: sfptpd
  namespace: sfptpd
spec:
  selector:
    matchLabels:
      name: sfptpd
  template:
    metadata:
      labels:
        name: sfptpd
    spec:
      containers:
      - args:
        - -f
        - /etc/sfptpd/sfptpd.cfg
        image: docker.io/onload/sfptpd:3.7.1.1000
        imagePullPolicy: Always
        name: sfptpd
        securityContext:
          privileged: true
        volumeMounts:
        - mountPath: /etc/sfptpd
          name: etc-sfptpd
      hostNetwork: true
      nodeSelector:
        node-role.kubernetes.io/ptp: ""
        node-role.kubernetes.io/worker: ""
      serviceAccountName: sfptpd
      volumes:
      - configMap:
          name: sfptpd-config-c65fbfbchb
        name: etc-sfptpd
```
