### PR TITLE
Cleanup: Add -p option to mkdir in device plugin init container

### DIFF
--- a/controllers/onload_controller.go
+++ b/controllers/onload_controller.go
@@ -996,10 +996,14 @@ func (r *OnloadReconciler) createDevicePluginDaemonSet(
 		ImagePullPolicy: onload.Spec.Onload.ImagePullPolicy,
 		Command: []string{
 			"/bin/sh", "-c",
+			// The Kubelet can be configured to store an emptyDir in the host's
+			// filesystem. `mkdir -p` is used in the case of a node reboot the
+			// emptyDir might be older than the actual pod, so the initContainer
+			// shouldn't fail if the directory already exists.
 			`set -e;
 			cp -TRv /opt/onload /host/onload;
 
-			mkdir -v /mnt/onload/sbin/;
+			mkdir -vp /mnt/onload/sbin/;
 			cp -v /opt/onload/sbin/onload_cp_server /mnt/onload/sbin/;
 			`,
 		},


### PR DESCRIPTION
Krish found that if a user applied a new sfc MachineConfig without first deleting the onload CR then when the node rebooted the device plugin pods were unable to restart. I believe that the issue was caused by a call to `mkdir` in the initContainer failing because the directory already existed.

## Testing done
I haven't re-tested the exact same scenario (applying a MachineConfig), but on a virtualised cluster I rebooted one of the worker nodes and waited for it to get back in a good state. Once the node was back online the pods were created without issue.