### PR TITLE
ON-15420: Fix Onload spec for in-cluster case

### DIFF
--- a/config/samples/in-cluster-build/patch-build.yaml
+++ b/config/samples/in-cluster-build/patch-build.yaml
@@ -8,6 +8,8 @@ spec:
   onload:
     kernelMappings:
       - regexp: '^.*\.x86_64$'
+        kernelModuleImage: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-module:v8.1.0-${KERNEL_FULL_VERSION}
+        sfc: {}
         build:
           dockerfileConfigMap:
             name: onload-module-dockerfile


### PR DESCRIPTION
Otherwise:

```
$ kubectl apply -k config/samples/in-cluster-build ...
The Onload "onload-sample" is invalid: spec.onload.kernelMappings[0].kernelModuleImage: Required value
```
The missing values are copied from onload_v1alpha1_onload.yaml.