### PR TITLE
cleanup: Allow chcon failures when labelling Onload files

### DIFF
--- a/controllers/onload_controller.go
+++ b/controllers/onload_controller.go
@@ -945,7 +945,8 @@ func (r *OnloadReconciler) createDevicePluginDaemonSet(
 			Command: []string{
 				"/bin/sh", "-c",
 				`set -e;
-				chcon --type container_file_t --recursive /opt/onload/;`,
+				chcon --type container_file_t --recursive /opt/onload/ ||
+				echo "chcon failed. System may not be SELinux enabled.";`,
 			},
 		},
 	}


### PR DESCRIPTION
`chcon` fails in systems with disabled SELinux:
```
FailedPostStartHook  30m (x3 over 30m)  kubelet            Exec lifecycle hook ([/bin/sh -c set -e;
cp -TRv /opt/onload /host/onload;
chcon --verbose --type container_file_t --recursive /host/onload/;
]) for Container "onload-device-plugin" in Pod "dev-onload-device-plugin-ds-jxgdk_onload-runtime(b1c1ac52-6deb-4de7-b85b-d9aa0f558b23)" failed - error: command '/bin/sh -c set -e;
cp -TRv /opt/onload /host/onload;
chcon --verbose --type container_file_t --recursive /host/onload/;
' exited with 1: chcon: can't apply partial context to unlabeled file 'openonload'
chcon: can't apply partial context to unlabeled file 'onload.modules'
chcon: can't apply partial context to unlabeled file 'modules'
chcon: can't apply partial context to unlabeled file 'sysconfig'
chcon: can't apply partial context to unlabeled file 'etc'
chcon: can't apply partial context to unlabeled file 'onload_cp_server'
chcon: can't apply partial context to unlabeled file 'onload_tool'
chcon: can't apply partial context to unlabeled file 'sbin'
chcon: can't apply partial context to unlabeled file 'onload'
chcon: can't apply partial context to unlabeled file 'onload_fuser'
chcon: can't apply partial context to unlabeled file 'onload_iptables'
chcon: can't apply partial context to unlabeled file 'onload_mibdump'
chcon: can't apply partial context to unlabeled file 'onload_stackdump'
chcon: can't apply partial context to unlabeled file 'onload_tcpdump'
chcon: can't apply partial context to unlabeled file 'onload_tcpdump.bin'
```
This patch relaxes the error checking because chcon is the best effort approach anyway, e.g. it won't survive the file system relabelling.