### PR TITLE
Set Device Plugin Image at controller level

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -40,9 +40,9 @@ Deploy the Onload Operator:
 ```sh
 make deploy IMG=$REGISTRY_BASE/operator:latest
 ```
+Ensure that `$DEVICE_IMG` is exported when deploying the operator, or append `DEVICE_IMG=...` to the make invocation.
 
 Continue with [deploying the Onload CR](README.md#onload-custom-resource-cr).
-Ensure the `devicePluginImage` is set to the above `$DEVICE_IMG`.
 
 
 ## Footnotes

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG} deviceplugin=${DEVICE_IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy

--- a/api/v1alpha1/onload_types.go
+++ b/api/v1alpha1/onload_types.go
@@ -78,8 +78,6 @@ type OnloadSpec struct {
 // Currently unimplemented
 // +kubebuilder:validation:XValidation:message="SetPreload and MountOnload mutually exclusive",rule="!(self.setPreload && self.mountOnload)"
 type DevicePluginSpec struct {
-	// DevicePluginImage
-	DevicePluginImage string `json:"devicePluginImage"`
 
 	// +optional
 	// ImagePullPolicy is the policy used when pulling images.

--- a/config/crd/bases/onload.amd.com_onloads.yaml
+++ b/config/crd/bases/onload.amd.com_onloads.yaml
@@ -51,9 +51,6 @@ spec:
                     description: BinMountPath is the location to mount onload binaries
                       in the container's filesystem.
                     type: string
-                  devicePluginImage:
-                    description: DevicePluginImage
-                    type: string
                   hostOnloadPath:
                     default: /opt/onload/
                     description: HostOnloadPath is the base location of onload files
@@ -88,8 +85,6 @@ spec:
                       will set LD_PRELOAD for pods using Onload. Mutually exclusive
                       with MountOnload
                     type: boolean
-                required:
-                - devicePluginImage
                 type: object
                 x-kubernetes-validations:
                 - message: SetPreload and MountOnload mutually exclusive

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,3 +9,9 @@ images:
 - name: controller
   newName: docker.io/onload/onload-operator
   newTag: 3.0.0
+- name: deviceplugin
+  newName: docker.io/onload/onload-device-plugin
+  newTag: 3.0.0
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/manager/kustomizeconfig.yaml
+++ b/config/manager/kustomizeconfig.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+images:
+- path: spec/template/spec/containers/env/value
+  kind: Deployment

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,6 +74,9 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        env:
+        - name: DEVICE_PLUGIN_IMG
+          value: deviceplugin
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/samples/default-clusterlocal/kustomization.yaml
+++ b/config/samples/default-clusterlocal/kustomization.yaml
@@ -6,5 +6,8 @@ resources:
 
 images:
 - name: docker.io/onload/onload-operator
-  newName: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload/onload-operator
+  newName: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-operator
+  newTag: 3.0.0
+- name: deviceplugin
+  newName: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-device-plugin
   newTag: 3.0.0

--- a/config/samples/onload/base/configurations.yaml
+++ b/config/samples/onload/base/configurations.yaml
@@ -9,8 +9,6 @@ nameReference:
 images:
 - path: spec/onload/userImage
   kind: Onload
-- path: spec/devicePlugin/devicePluginImage
-  kind: Onload
 - path: spec/onload/kernelMappings/kernelModuleImage
   kind: Onload
 - path: spec/onload/kernelMappings/build/buildArgs/value

--- a/config/samples/onload/base/onload_v1alpha1_onload.yaml
+++ b/config/samples/onload/base/onload_v1alpha1_onload.yaml
@@ -51,7 +51,6 @@ spec:
     version:
     imagePullPolicy: Always
   devicePlugin:
-    devicePluginImage: onload/onload-device-plugin:3.0.0
     imagePullPolicy: Always
     # Limit number of pods that can request Onload on a node
     #maxPodsPerNode: 100

--- a/config/samples/onload/overlays/in-cluster-build-ocp-clusterlocal/kustomization.yaml
+++ b/config/samples/onload/overlays/in-cluster-build-ocp-clusterlocal/kustomization.yaml
@@ -9,10 +9,6 @@ patches:
 - path: patch-onload.yaml
 
 images:
-- name: onload/onload-device-plugin
-  newName: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-device-plugin
-  newTag: 3.0.0
-
 - name: onload/onload-source
   newName: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-source
   newTag: 8.1.2.26

--- a/config/samples/onload/overlays/in-cluster-build-ocp/kustomization.yaml
+++ b/config/samples/onload/overlays/in-cluster-build-ocp/kustomization.yaml
@@ -10,10 +10,6 @@ patches:
 - path: patch-onload.yaml
 
 images:
-#- name: onload/onload-device-plugin
-#  newName: docker.io/onload/onload-device-plugin
-#  newTag: 3.0.0
-
 - name: onload/onload-source
   newName: docker.io/onload/onload-source
   newTag: 8.1.2.26

--- a/controllers/onload_controller.go
+++ b/controllers/onload_controller.go
@@ -37,7 +37,8 @@ import (
 // OnloadReconciler reconciles a Onload object
 type OnloadReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme            *runtime.Scheme
+	DevicePluginImage string
 }
 
 //+kubebuilder:rbac:groups=onload.amd.com,resources=onloads,verbs=get;list;watch;create;update;patch;delete
@@ -910,7 +911,7 @@ func (r *OnloadReconciler) createDevicePluginDaemonSet(
 
 	devicePluginContainer := corev1.Container{
 		Name:            "device-plugin",
-		Image:           onload.Spec.DevicePlugin.DevicePluginImage,
+		Image:           r.DevicePluginImage,
 		ImagePullPolicy: onload.Spec.DevicePlugin.ImagePullPolicy,
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: ptr.To(true),
@@ -1007,7 +1008,7 @@ func (r *OnloadReconciler) createDevicePluginDaemonSet(
 
 	workerContainer := corev1.Container{
 		Name:            workerContainerName,
-		Image:           onload.Spec.DevicePlugin.DevicePluginImage,
+		Image:           r.DevicePluginImage,
 		ImagePullPolicy: onload.Spec.DevicePlugin.ImagePullPolicy,
 
 		Command: []string{

--- a/controllers/onload_controller_test.go
+++ b/controllers/onload_controller_test.go
@@ -588,9 +588,7 @@ var _ = Describe("onload controller", func() {
 						UserImage: "image:tag",
 						Version:   "",
 					},
-					DevicePlugin: onloadv1alpha1.DevicePluginSpec{
-						DevicePluginImage: "image:tag",
-					},
+					DevicePlugin:       onloadv1alpha1.DevicePluginSpec{},
 					ServiceAccountName: "",
 				},
 			}
@@ -800,7 +798,6 @@ var _ = Describe("onload controller", func() {
 				}
 
 				if dev != nil {
-					dev.DevicePluginImage = "image:tag"
 					onload.Spec.DevicePlugin = *dev
 				}
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -88,8 +88,9 @@ var _ = BeforeSuite(func() {
 	Expect(k8sManager).NotTo(BeNil())
 
 	err = (&OnloadReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
+		Client:            k8sManager.GetClient(),
+		Scheme:            k8sManager.GetScheme(),
+		DevicePluginImage: "image:tag",
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Previously the device plugin image would be set per Onload CR, this could potentially lead to confusion since (we expect) most users won't need to change the device plugin image nor have fine-grained control of the image. Additionally, since we have built the controller with certain assumptions of the device plugin image it should lower the chances that a user sets this to an incompatible value.

I have left a field for the ImagePullPolicy in the `DevicePluginSpec` struct, though I'm wondering how necessary that is.

## Testing done
Tested in virtualised cluster, when an onload CR is created it creates the device plugin correctly.

Since the value of the device plugin image is set at operator deploy time, I have found that the best way to deploy the operator is with the command
```
make deploy IMG=... DEVICE_IMG=...
```