### PR TITLE
cleanup: Add ContainerFileNotices for Ubuntu & MachineConfig

### DIFF
--- a/config/samples/onload/onload-module/ubuntu/ContainerFileNotice
+++ b/config/samples/onload/onload-module/ubuntu/ContainerFileNotice
@@ -1,0 +1,42 @@
+NOTICE - BY INVOKING THIS SCRIPT AND USING THE SOFTWARE INSTALLED BY THE
+SCRIPT, YOU AGREE ON BEHALF OF YOURSELF AND YOUR EMPLOYER (IF APPLICABLE) TO BE
+BOUND TO THE LICENSE AGREEMENTS APPLICABLE TO THE PACKAGES IDENTIFIED BELOW
+THAT YOU INSTALL BY RUNNING THE SCRIPT. YOU UNDERSTAND THAT THE INSTALLATION OF
+THE PACKAGES LISTED BELOW MAY ALSO RESULT IN THE INSTALLATION ON YOUR SYSTEM OF
+ADDITIONAL PACKAGES NOT LISTED BELOW IN ORDER TO OPERATE (EACH, A
+‘DEPENDENCY’). ADVANCED MICRO DEVICES, INC., ON BEHALF OF ITSELF AND ITS
+SUBSIDIARIES AND AFFILIATES, DOES NOT GRANT TO YOU ANY RIGHTS OR LICENSES TO
+ANY SUCH DEPENDENCY. THE SCRIPT ITSELF IS LICENSED TO YOU SUBJECT TO THE
+FOLLOWING TERMS:
+
+Copyright © 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+
+This file is licensed under the following license terms (MIT):
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+This file pulls in the following packages subject to the licenses identified
+below:
+
+| Package, Version                 | License      | URL                                                                                    |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|
+| AMD Onload, Various              | GPL-2.0-only | https://github.com/Xilinx-CNS/onload/blob/master/src/onload/distfiles/LICENSE          |
+|                                  | AND          |                                                                                        |
+|                                  | BSD-2-Clause |                                                                                        |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|

--- a/scripts/machineconfig/ContainerFileNotice
+++ b/scripts/machineconfig/ContainerFileNotice
@@ -1,0 +1,40 @@
+NOTICE - BY INVOKING THIS SCRIPT AND USING THE SOFTWARE INSTALLED BY THE
+SCRIPT, YOU AGREE ON BEHALF OF YOURSELF AND YOUR EMPLOYER (IF APPLICABLE) TO BE
+BOUND TO THE LICENSE AGREEMENTS APPLICABLE TO THE PACKAGES IDENTIFIED BELOW
+THAT YOU INSTALL BY RUNNING THE SCRIPT. YOU UNDERSTAND THAT THE INSTALLATION OF
+THE PACKAGES LISTED BELOW MAY ALSO RESULT IN THE INSTALLATION ON YOUR SYSTEM OF
+ADDITIONAL PACKAGES NOT LISTED BELOW IN ORDER TO OPERATE (EACH, A
+‘DEPENDENCY’). ADVANCED MICRO DEVICES, INC., ON BEHALF OF ITSELF AND ITS
+SUBSIDIARIES AND AFFILIATES, DOES NOT GRANT TO YOU ANY RIGHTS OR LICENSES TO
+ANY SUCH DEPENDENCY. THE SCRIPT ITSELF IS LICENSED TO YOU SUBJECT TO THE
+FOLLOWING TERMS:
+
+Copyright © 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+
+This file is licensed under the following license terms (MIT):
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+This file pulls in the following packages subject to the licenses identified
+below:
+
+| Package, Version                 | License      | URL                                                                                    |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|
+| Butane, v0.19.0                  | Apache-2.0   | https://github.com/coreos/butane/blob/v0.19.0/LICENSE                                  |
+|----------------------------------+--------------+----------------------------------------------------------------------------------------|


### PR DESCRIPTION
There are two new Dockefiles: one to generate SFC MachineConfig, and another is an Onload kernel module builder for the Ubuntu kernels. This patch adds the corresponding ContainerFileNotice even though the latter image is a template.

---

Re on Dockerfiles:

- I chose the specific version of Butane (v0.19.0), which must be the latest `release` tag.
- Ubuntu is borderline, as we don't build these images, but added for completeness.