### PR TITLE
Cleanup: Fix in-cluster-build sample

### DIFF
--- a/config/samples/onload/overlays/in-cluster-build-ocp-clusterlocal/imagestream.yaml
+++ b/config/samples/onload/overlays/in-cluster-build-ocp-clusterlocal/imagestream.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: onload-clusterlocal
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:image-builder
+  namespace: onload-clusterlocal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-builder
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts

--- a/config/samples/onload/overlays/in-cluster-build-ocp-clusterlocal/kustomization.yaml
+++ b/config/samples/onload/overlays/in-cluster-build-ocp-clusterlocal/kustomization.yaml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 resources:
+- imagestream.yaml
 - ../../base
 - ../../onload-module/dtk-only
 

--- a/config/samples/onload/overlays/in-cluster-build-ocp/imagestream.yaml
+++ b/config/samples/onload/overlays/in-cluster-build-ocp/imagestream.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: onload-clusterlocal
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:image-builder
+  namespace: onload-clusterlocal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-builder
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts

--- a/config/samples/onload/overlays/in-cluster-build-ocp/kustomization.yaml
+++ b/config/samples/onload/overlays/in-cluster-build-ocp/kustomization.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 resources:
+- imagestream.yaml
 - ../../base
 - ../../onload-module/dtk-ubi
 
@@ -20,5 +21,5 @@ images:
   newName: docker.io/onload/onload-user
   newTag: 8.1.2.26
 - name: onload/onload-module
-  newName: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload/onload-module
+  newName: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-module
   newTag: 8.1.2.26-${KERNEL_FULL_VERSION}


### PR DESCRIPTION
I found two issues with the existing samples for in-cluster-builds:
1. If the `onload-clusterlocal` didn't exist with the correct RoleBindings, then the KMM operator would fail to check whether the image existed (which prevented a build happening).
2. Incorrect ImageStream specification (we were including an unnecessary `/onload`).

Both should be fixed with this patch.

The duplication of `imagestream.yaml` isn't ideal, but `in-cluster-build-ocp` and `in-cluster-build-ocp-clusterlocal` already have identical files (`patch-onload.yaml`) so I don't think it is the end of the world.

## Testing done
On `master`: `oc create -k config/samples/onload/overlays/in-cluster-build-ocp` creates and Onload CR, but the KMM fails to create a build pod for the module.
With this patch it can create the build pod which runs correctly.