### PR TITLE
cleanup: Tagged README examples (v3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ implemented here in the `Onload` *kind* of CRD.
 To deploy the Onload Operator, its controller container and CRD, run:
 
 ```sh
-kubectl apply -k https://github.com/Xilinx-CNS/kubernetes-onload/config/default
+kubectl apply -k https://github.com/Xilinx-CNS/kubernetes-onload/config/default?ref=v3.0
 ```
 
 This deploys the following by default:
@@ -118,7 +118,7 @@ To run the above command using locally hosted container images, open this reposi
 [following overlay](config/samples/default-clusterlocal/kustomization.yaml):
 
 ```sh
-git clone https://github.com/Xilinx-CNS/kubernetes-onload && cd kubernetes-onload
+git clone -b v3.0 https://github.com/Xilinx-CNS/kubernetes-onload && cd kubernetes-onload
 
 cp -r config/samples/default-clusterlocal config/samples/my-operator
 $EDITOR config/samples/my-operator/kustomization.yaml
@@ -144,7 +144,7 @@ If your cluster is internet-connected OpenShift and you want to use in-cluster b
 of OpenOnload, run:
 
 ```sh
-kubectl apply -k https://github.com/Xilinx-CNS/kubernetes-onload/config/samples/onload/overlays/in-cluster-build-ocp
+kubectl apply -k https://github.com/Xilinx-CNS/kubernetes-onload/config/samples/onload/overlays/in-cluster-build-ocp?ref=v3.0
 ```
 
 This takes a [base `Onload` CR template](config/samples/onload/base/onload_v1alpha1_onload.yaml) and adds the
@@ -162,7 +162,7 @@ to suit your environment. For example, to adapt the overlay
 [in-cluster build on OpenShift in restricted network](config/samples/onload/overlays/in-cluster-build-ocp-clusterlocal):
 
 ```sh
-git clone https://github.com/Xilinx-CNS/kubernetes-onload && cd kubernetes-onload
+git clone -b v3.0 https://github.com/Xilinx-CNS/kubernetes-onload && cd kubernetes-onload
 
 cd config/samples/onload
 cp -r overlays/in-cluster-build-ocp-clusterlocal overlays/my-onload
@@ -293,7 +293,7 @@ We have included an example definition for the 'latency' profile in
 To deploy a ConfigMap named `onload-latency-profile` in the current namespace:
 
 ```sh
-kubectl apply -k https://github.com/Xilinx-CNS/kubernetes-onload/config/samples/profiles
+kubectl apply -k https://github.com/Xilinx-CNS/kubernetes-onload/config/samples/profiles?ref=v3.0
 ```
 
 To use this in your pod, add the following to the container spec in your pod definition:


### PR DESCRIPTION
Tracking major/minor tags (v3/v3.0) for default branch commits so we can regulate enthusiastic user access. This PR suggests minor tag but major would be fine with me too.

Release snapshot tags (v3.0.0, ie. revision+) won't change and will be recommended in Release Notes.

Examples:

```sh
kubernetes-onload$ oc apply -k 'https://github.com/Xilinx-CNS/kubernetes-onload/config/default?ref=v3.0'
error: git cmd = '/usr/bin/git fetch --depth=1 origin v3.0': exit status 128
```

```sh
kubernetes-onload$ git tag v3.0 && git push origin v3.0
kubernetes-onload$ oc apply -k https://github.com/pcolledg-amd/kubernetes-onload/config/default?ref=v3.0
namespace/onload-operator-system unchanged
Warning: resource customresourcedefinitions/onloads.onload.amd.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by oc apply. oc apply should only be used on resources created declaratively by either oc create --save-config or oc apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/onloads.onload.amd.com configured
serviceaccount/onload-operator-controller-manager unchanged
role.rbac.authorization.k8s.io/onload-operator-leader-election-role unchanged
clusterrole.rbac.authorization.k8s.io/onload-operator-manager-role unchanged
clusterrole.rbac.authorization.k8s.io/onload-operator-metrics-reader unchanged
clusterrole.rbac.authorization.k8s.io/onload-operator-proxy-role unchanged
rolebinding.rbac.authorization.k8s.io/onload-operator-leader-election-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/onload-operator-manager-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/onload-operator-proxy-rolebinding unchanged
service/onload-operator-controller-manager-metrics-service unchanged

$ git clone -b v3.0 https://github.com/pcolledg-amd/kubernetes-onload `mktemp -d`
Cloning into '/tmp/tmp.8vHdBcGR8d'...
...
You are in 'detached HEAD' state. ...
```
