### PR TITLE
cleanup: Consistent KERNEL_FULL_VERSION & Dockerfile /opt

### DIFF
--- a/config/samples/onload/onload-module/dtk-only/Dockerfile
+++ b/config/samples/onload/onload-module/dtk-only/Dockerfile
@@ -22,3 +22,4 @@ RUN mkdir -p /opt/lib/modules/$KERNEL_FULL_VERSION
 RUN cp -v /lib/modules/$KERNEL_FULL_VERSION/modules* /opt/lib/modules/$KERNEL_FULL_VERSION/
 RUN cp -rv /lib/modules/$KERNEL_FULL_VERSION/extra /opt/lib/modules/$KERNEL_FULL_VERSION/extra
 RUN ln -s /lib/modules/$KERNEL_FULL_VERSION/kernel /opt/lib/modules/$KERNEL_FULL_VERSION/kernel
+

--- a/config/samples/onload/onload-module/dtk-ubi/Dockerfile
+++ b/config/samples/onload/onload-module/dtk-ubi/Dockerfile
@@ -26,3 +26,4 @@ RUN microdnf install -y kmod && microdnf clean all
 COPY --from=builder /lib/modules/$KERNEL_FULL_VERSION/modules* /opt/lib/modules/$KERNEL_FULL_VERSION/
 COPY --from=builder /lib/modules/$KERNEL_FULL_VERSION/extra /opt/lib/modules/$KERNEL_FULL_VERSION/extra
 RUN ln -s /lib/modules/$KERNEL_FULL_VERSION/kernel /opt/lib/modules/$KERNEL_FULL_VERSION/kernel
+

--- a/config/samples/onload/onload-module/mkdist-direct/Dockerfile
+++ b/config/samples/onload/onload-module/mkdist-direct/Dockerfile
@@ -16,14 +16,15 @@ RUN mkdir -p /build/onload
 RUN tar xzf onload.tar.gz -C /build/onload --strip-components=1
 WORKDIR /build/onload/
 
-ENV i_prefix=/opt
-RUN scripts/onload_build --kernel --kernelver $KERNEL_FULL_VERSION $ONLOAD_BUILD_PARAMS && \
-    scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERSION && \
-    make -j8 -C src/driver/linux_net CONFIG_SFC_VDPA= CONFIG_SFC_MTD= KVER=$KERNEL_FULL_VERSION && \
-    /sbin/depmod -b /opt $KERNEL_FULL_VERSION
+RUN scripts/onload_build --kernel --kernelver $KERNEL_FULL_VERSION $ONLOAD_BUILD_PARAMS
+RUN scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERSION
+RUN depmod $KERNEL_FULL_VERSION
 
 
 FROM $UBI_BASE
-ARG KERNEL_VERSION
-RUN microdnf install -y kmod && dnf clean all
-COPY --from=builder /opt/lib/modules/ /opt/lib/modules/
+ARG KERNEL_FULL_VERSION
+RUN microdnf install -y kmod && microdnf clean all
+COPY --from=builder /lib/modules/$KERNEL_FULL_VERSION/modules* /opt/lib/modules/$KERNEL_FULL_VERSION/
+COPY --from=builder /lib/modules/$KERNEL_FULL_VERSION/extra /opt/lib/modules/$KERNEL_FULL_VERSION/extra
+RUN ln -s /lib/modules/$KERNEL_FULL_VERSION/kernel /opt/lib/modules/$KERNEL_FULL_VERSION/kernel
+

--- a/config/samples/onload/onload-module/ubuntu/Dockerfile
+++ b/config/samples/onload/onload-module/ubuntu/Dockerfile
@@ -22,15 +22,19 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     git \
     make \
     gcc \
-    "linux-headers-$KERNEL_VERSION"
+    "linux-headers-$KERNEL_FULL_VERSION"
 
 COPY --from=onload-source / /opt/onload
 WORKDIR /opt/onload
-ENV i_prefix=/opt
-RUN scripts/onload_build --kernel --kernelver $KERNEL_FULL_VERSION $ONLOAD_BUILD_PARAMS && \
-    scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERSION
+RUN scripts/onload_build --kernel --kernelver $KERNEL_FULL_VERSION $ONLOAD_BUILD_PARAMS
+RUN scripts/onload_install --nobuild --kernelfiles --kernelver $KERNEL_FULL_VERSION
+RUN depmod $KERNEL_FULL_VERSION
 
 
 FROM $UBUNTU_IMAGE
-COPY --from=builder /opt/lib/modules/ /opt/lib/modules/
-RUN /sbin/depmod -b /opt
+ARG KERNEL_FULL_VERSION
+RUN apt-get update && apt-get install -y kmod && apt-get clean
+COPY --from=builder /lib/modules/$KERNEL_FULL_VERSION/modules* /opt/lib/modules/$KERNEL_FULL_VERSION/
+COPY --from=builder /lib/modules/$KERNEL_FULL_VERSION/extra /opt/lib/modules/$KERNEL_FULL_VERSION/extra
+RUN ln -s /lib/modules/$KERNEL_FULL_VERSION/kernel /opt/lib/modules/$KERNEL_FULL_VERSION/kernel
+

--- a/scripts/machineconfig/README.md
+++ b/scripts/machineconfig/README.md
@@ -34,7 +34,7 @@ Run:
 
 ```sh
 #export OPENSHIFT_VER=4.14.0 # Default is v4.10.0 to 4.13.0
-make sfc-mc-build ONLOAD_MODULE_IMAGE=$REGISTRY_BASE/onload-module:$ONLOAD_VERSION-$ONLOAD_KERNEL_VERSION
+make sfc-mc-build ONLOAD_MODULE_IMAGE=$REGISTRY_BASE/onload-module:$ONLOAD_VERSION-$KERNEL_FULL_VERSION
 ```
 
 ### Docker method
@@ -48,7 +48,7 @@ Run:
 
 ```sh
 #export OPENSHIFT_VER=4.14.0 # Default is v4.10.0 to 4.13.0
-make sfc-mc-docker-build ONLOAD_MODULE_IMAGE=$REGISTRY_BASE/onload-module:$ONLOAD_VERSION-$ONLOAD_KERNEL_VERSION
+make sfc-mc-docker-build ONLOAD_MODULE_IMAGE=$REGISTRY_BASE/onload-module:$ONLOAD_VERSION-$KERNEL_FULL_VERSION
 ```
 
 ## Deploying the SFC MachineConfig


### PR DESCRIPTION
The `depmod` `/opt` issue fixed in primary Dockerfiles now copied to supplementary; some also had inconsistent (broken) KERNEL_VERSION vs KERNEL_FULL_VERSION.