### PR TITLE
ON-15462: Docs - Onload CR inline comments and links to CRD source; sfc default

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ the Onload Operator. Its image location is configured as an environment variable
 
 ### Onload Custom Resource (CR)
 
-Instruct the Onload Operator to deploy the components necessary for accelerating workload pods by deploying
-a `Onload` *kind* of Custom Resource (CR).
+Instruct the Onload Operator to deploy the components necessary for accelerating workload pods by deploying an `Onload`
+*kind* of [Custom Resource (CR)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
 If your cluster is internet-connected OpenShift and you want to use in-cluster builds with the current version
 of OpenOnload, run:
@@ -159,10 +159,17 @@ kubectl apply -k https://github.com/Xilinx-CNS/kubernetes-onload/config/samples/
 This takes a [base `Onload` CR template](config/samples/onload/base/onload_v1alpha1_onload.yaml) and adds the
 appropriate [image versions](config/samples/onload/overlays/in-cluster-build-ocp/kustomization.yaml) and
 [in-cluster build configuration](config/samples/onload/overlays/in-cluster-build-ocp/patch-onload.yaml). To customise
-this recommended overlay further, see the variant steps below.
+this recommended overlay further, see comments in these files and the variant steps below.
 
-The above overlay configures KMM to `modprobe onload` but `modprobe sfc` is also required.
-Please see [Out-of-tree `sfc` module](#out-of-tree-sfc-kernel-module) for options.
+The above overlay configures KMM to `modprobe onload` and `modprobe sfc`. Both are required, but the latter may occur
+outside the Onload Operator. Please see [Out-of-tree `sfc` module](#out-of-tree-sfc-kernel-module) for options.
+
+For further explanation of `Onload` CR's available properties, refer to either inline comments in these templates or
+the built-in explain command, eg. `kubectl explain onload.spec`.
+
+The schema for the above templates is defined by an `Onload` [Custom Resource Definition (CRD)](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/)
+in [onload_types.go](api/v1alpha1/onload_types.go) which is distributed as part of Onload Operator's
+[generated YAML bundle](config/crd/bases/onload.amd.com_onloads.yaml).
 
 > [!IMPORTANT]
 > Due to Kubernetes limitations on label lengths, the combined length of the Name and Namespace of the Onload CR must be less than 32 characters.
@@ -215,7 +222,7 @@ with a Solarflare card.
 
 The following methods may be used:
 
-* Configure the Onload Operator to deploy a KMM Module for `sfc`. Please see the example comment in
+* Configure the Onload Operator to deploy a KMM Module for `sfc`. Please see the example in
   [in-cluster build configuration](config/samples/onload/overlays/in-cluster-build-ocp/patch-onload.yaml).
 
 * [OpenShift MachineConfig for Day 0/1 sfc](#openshift-machineconfig-for-sfc). This is for when newer driver features

--- a/api/v1alpha1/onload_types.go
+++ b/api/v1alpha1/onload_types.go
@@ -9,6 +9,9 @@ import (
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+// NOTE: Update sample properties in:
+//       - config/samples/onload/base/onload_v1alpha1_onload.yaml
+//       - config/samples/onload/overlays/in-cluster-build-ocp/patch-onload.yaml
 
 // Currently unimplemented
 type SFCSpec struct {
@@ -33,16 +36,16 @@ type OnloadKernelBuild struct {
 
 type OnloadKernelMapping struct {
 	// Regexp is a regular expression that is used to match against the kernel
-	// versions of the nodes in the cluster
+	// versions of the nodes in the cluster. Use also in place of literal strings.
 	Regexp string `json:"regexp"`
 
 	// KernelModuleImage is the image that contains the out-of-tree kernel
-	// modules used by Onload.
+	// modules used by Onload. Absent image tags may be built by KMM.
 	KernelModuleImage string `json:"kernelModuleImage"`
 
 	// +optional
 	// SFC optionally specifies that the controller will manage the SFC
-	// kernel module.
+	// kernel module. Incompatible with boot-time loading approaches.
 	SFC *SFCSpec `json:"sfc,omitempty"`
 
 	// +optional
@@ -50,7 +53,7 @@ type OnloadKernelMapping struct {
 	// Management operator when building the images that contain the module.
 	// The build process creates a new image which will be written to the
 	// location specified by the `KernelModuleImage` parameter.
-	// If empty no builds will take place.
+	// If empty, no builds will take place.
 	Build *OnloadKernelBuild `json:"build,omitempty"`
 }
 
@@ -63,10 +66,10 @@ type OnloadSpec struct {
 	KernelMappings []OnloadKernelMapping `json:"kernelMappings"`
 
 	// UserImage is the image that contains the built userland objects, used
-	// by the cplane and deviceplugin DaemonSets.
+	// within the Onload Device Plugin DaemonSet.
 	UserImage string `json:"userImage"`
 
-	// Version string to associate with this onload CR.
+	// Version string to associate with this Onload CR.
 	Version string `json:"version"`
 
 	// +optional
@@ -87,7 +90,7 @@ type DevicePluginSpec struct {
 	// +optional
 	// MaxPodsPerNode is the number of Kubernetes devices that the Onload
 	// Device Plugin should register with the kubelet. Notionally this is
-	// equivalent to the number of pods that can request an onload resource on
+	// equivalent to the number of pods that can request an Onload resource on
 	// each node.
 	// +kubebuilder:default:=100
 	MaxPodsPerNode *int `json:"maxPodsPerNode,omitempty"`
@@ -108,46 +111,47 @@ type DevicePluginSpec struct {
 	MountOnload *bool `json:"mountOnload,omitempty"`
 
 	// +optional
-	// HostOnloadPath is the base location of onload files on the host
+	// HostOnloadPath is the base location of Onload files on the host
 	// filesystem.
 	// +kubebuilder:default=/opt/onload/
 	HostOnloadPath *string `json:"hostOnloadPath,omitempty"`
 
 	// +optional
-	// BaseMountPath is a prefix to be applied to all onload file mounts in the
+	// BaseMountPath is a prefix to be applied to all Onload file mounts in the
 	// container's filesystem.
 	// +kubebuilder:default=/opt/onload
 	BaseMountPath *string `json:"baseMountPath,omitempty"`
 
 	// +optional
-	// BinMountPath is the location to mount onload binaries in the container's
+	// BinMountPath is the location to mount Onload binaries in the container's
 	// filesystem.
 	// +kubebuilder:default=/usr/bin
 	BinMountPath *string `json:"binMountPath,omitempty"`
 
 	// +optional
-	// LibMountPath is the location to mount onload libraries in the container's
+	// LibMountPath is the location to mount Onload libraries in the container's
 	// filesystem.
 	// +kubebuilder:default=/usr/lib64
 	LibMountPath *string `json:"libMounthPath,omitempty"`
 }
 
-// Spec is the top-level specification for onload and related products that are
-// controlled by the onload operator
+// Spec is the top-level specification for Onload and related products that are
+// controlled by the Onload Operator
 type Spec struct {
-	// Onload is the specification of the version of onload to be used by this
+	// Onload is the specification of the version of Onload to be used by this
 	// CR
 	Onload OnloadSpec `json:"onload"`
 
-	// DevicePlugin is the specification of the device plugin that will add a
-	// new onload resource into the cluster.
+	// DevicePlugin is further specification for the Onload Device Plugin which
+	// uses the device plugin framework to provide an `amd.com/onload` resource.
+	// Image location is not configured here; see Onload Operator deployment.
 	DevicePlugin DevicePluginSpec `json:"devicePlugin"`
 
-	// Selector defines the set of nodes that this onload CR will run on.
+	// Selector defines the set of nodes that this Onload CR will run on.
 	Selector map[string]string `json:"selector"`
 
 	// ServiceAccountName is the name of the service account that the objects
-	// created by the onload operator will use.
+	// created by the Onload Operator will use.
 	ServiceAccountName string `json:"serviceAccountName"`
 }
 
@@ -158,17 +162,17 @@ type OnloadStatus struct {
 type DevicePluginStatus struct {
 }
 
-// Status contains the statuses for onload and related products that are
-// controlled by the onload operator
+// Status contains the statuses for Onload and related products that are
+// controlled by the Onload Operator
 type Status struct {
 	// Conditions store the status conditions of Onload
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
-	// Status of onload components
+	// Status of Onload components
 	Onload OnloadStatus `json:"onload"`
 
-	// Status of the device plugin
+	// Status of Onload Device Plugin
 	DevicePlugin DevicePluginStatus `json:"devicePlugin"`
 }
 

--- a/bundle/manifests/onload-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/onload-operator.clusterserviceversion.yaml
@@ -36,7 +36,8 @@ metadata:
                     }
                   },
                   "kernelModuleImage": "image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-module:8.1.2.26-${KERNEL_FULL_VERSION}",
-                  "regexp": "^.*\\.x86_64$"
+                  "regexp": "^.*\\.x86_64$",
+                  "sfc": {}
                 }
               ],
               "userImage": "docker.io/onload/onload-user:8.1.2.26-ubi8",
@@ -50,7 +51,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-12-19T12:05:14Z"
+    createdAt: "2024-01-03T12:34:25Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: onload-operator.v3.0.0

--- a/bundle/manifests/onload.amd.com_onloads.yaml
+++ b/bundle/manifests/onload.amd.com_onloads.yaml
@@ -34,26 +34,28 @@ spec:
           metadata:
             type: object
           spec:
-            description: Spec is the top-level specification for onload and related
-              products that are controlled by the onload operator
+            description: Spec is the top-level specification for Onload and related
+              products that are controlled by the Onload Operator
             properties:
               devicePlugin:
-                description: DevicePlugin is the specification of the device plugin
-                  that will add a new onload resource into the cluster.
+                description: DevicePlugin is further specification for the Onload
+                  Device Plugin which uses the device plugin framework to provide
+                  an `amd.com/onload` resource. Image location is not configured here;
+                  see Onload Operator deployment.
                 properties:
                   baseMountPath:
                     default: /opt/onload
-                    description: BaseMountPath is a prefix to be applied to all onload
+                    description: BaseMountPath is a prefix to be applied to all Onload
                       file mounts in the container's filesystem.
                     type: string
                   binMountPath:
                     default: /usr/bin
-                    description: BinMountPath is the location to mount onload binaries
+                    description: BinMountPath is the location to mount Onload binaries
                       in the container's filesystem.
                     type: string
                   hostOnloadPath:
                     default: /opt/onload/
-                    description: HostOnloadPath is the base location of onload files
+                    description: HostOnloadPath is the base location of Onload files
                       on the host filesystem.
                     type: string
                   imagePullPolicy:
@@ -62,7 +64,7 @@ spec:
                     type: string
                   libMounthPath:
                     default: /usr/lib64
-                    description: LibMountPath is the location to mount onload libraries
+                    description: LibMountPath is the location to mount Onload libraries
                       in the container's filesystem.
                     type: string
                   maxPodsPerNode:
@@ -70,7 +72,7 @@ spec:
                     description: MaxPodsPerNode is the number of Kubernetes devices
                       that the Onload Device Plugin should register with the kubelet.
                       Notionally this is equivalent to the number of pods that can
-                      request an onload resource on each node.
+                      request an Onload resource on each node.
                     type: integer
                   mountOnload:
                     default: false
@@ -90,7 +92,7 @@ spec:
                 - message: SetPreload and MountOnload mutually exclusive
                   rule: '!(self.setPreload && self.mountOnload)'
               onload:
-                description: Onload is the specification of the version of onload
+                description: Onload is the specification of the version of Onload
                   to be used by this CR
                 properties:
                   imagePullPolicy:
@@ -109,7 +111,7 @@ spec:
                             building the images that contain the module. The build
                             process creates a new image which will be written to the
                             location specified by the `KernelModuleImage` parameter.
-                            If empty no builds will take place.
+                            If empty, no builds will take place.
                           properties:
                             buildArgs:
                               description: BuildArgs is an array of build variables
@@ -142,16 +144,18 @@ spec:
                           type: object
                         kernelModuleImage:
                           description: KernelModuleImage is the image that contains
-                            the out-of-tree kernel modules used by Onload.
+                            the out-of-tree kernel modules used by Onload. Absent
+                            image tags may be built by KMM.
                           type: string
                         regexp:
                           description: Regexp is a regular expression that is used
                             to match against the kernel versions of the nodes in the
-                            cluster
+                            cluster. Use also in place of literal strings.
                           type: string
                         sfc:
                           description: SFC optionally specifies that the controller
-                            will manage the SFC kernel module.
+                            will manage the SFC kernel module. Incompatible with boot-time
+                            loading approaches.
                           type: object
                       required:
                       - kernelModuleImage
@@ -160,10 +164,10 @@ spec:
                     type: array
                   userImage:
                     description: UserImage is the image that contains the built userland
-                      objects, used by the cplane and deviceplugin DaemonSets.
+                      objects, used within the Onload Device Plugin DaemonSet.
                     type: string
                   version:
-                    description: Version string to associate with this onload CR.
+                    description: Version string to associate with this Onload CR.
                     type: string
                 required:
                 - kernelMappings
@@ -173,12 +177,12 @@ spec:
               selector:
                 additionalProperties:
                   type: string
-                description: Selector defines the set of nodes that this onload CR
+                description: Selector defines the set of nodes that this Onload CR
                   will run on.
                 type: object
               serviceAccountName:
                 description: ServiceAccountName is the name of the service account
-                  that the objects created by the onload operator will use.
+                  that the objects created by the Onload Operator will use.
                 type: string
             required:
             - devicePlugin
@@ -187,8 +191,8 @@ spec:
             - serviceAccountName
             type: object
           status:
-            description: Status contains the statuses for onload and related products
-              that are controlled by the onload operator
+            description: Status contains the statuses for Onload and related products
+              that are controlled by the Onload Operator
             properties:
               conditions:
                 description: Conditions store the status conditions of Onload
@@ -260,10 +264,10 @@ spec:
                   type: object
                 type: array
               devicePlugin:
-                description: Status of the device plugin
+                description: Status of Onload Device Plugin
                 type: object
               onload:
-                description: Status of onload components
+                description: Status of Onload components
                 type: object
             required:
             - devicePlugin

--- a/config/crd/bases/onload.amd.com_onloads.yaml
+++ b/config/crd/bases/onload.amd.com_onloads.yaml
@@ -34,26 +34,28 @@ spec:
           metadata:
             type: object
           spec:
-            description: Spec is the top-level specification for onload and related
-              products that are controlled by the onload operator
+            description: Spec is the top-level specification for Onload and related
+              products that are controlled by the Onload Operator
             properties:
               devicePlugin:
-                description: DevicePlugin is the specification of the device plugin
-                  that will add a new onload resource into the cluster.
+                description: DevicePlugin is further specification for the Onload
+                  Device Plugin which uses the device plugin framework to provide
+                  an `amd.com/onload` resource. Image location is not configured here;
+                  see Onload Operator deployment.
                 properties:
                   baseMountPath:
                     default: /opt/onload
-                    description: BaseMountPath is a prefix to be applied to all onload
+                    description: BaseMountPath is a prefix to be applied to all Onload
                       file mounts in the container's filesystem.
                     type: string
                   binMountPath:
                     default: /usr/bin
-                    description: BinMountPath is the location to mount onload binaries
+                    description: BinMountPath is the location to mount Onload binaries
                       in the container's filesystem.
                     type: string
                   hostOnloadPath:
                     default: /opt/onload/
-                    description: HostOnloadPath is the base location of onload files
+                    description: HostOnloadPath is the base location of Onload files
                       on the host filesystem.
                     type: string
                   imagePullPolicy:
@@ -62,7 +64,7 @@ spec:
                     type: string
                   libMounthPath:
                     default: /usr/lib64
-                    description: LibMountPath is the location to mount onload libraries
+                    description: LibMountPath is the location to mount Onload libraries
                       in the container's filesystem.
                     type: string
                   maxPodsPerNode:
@@ -70,7 +72,7 @@ spec:
                     description: MaxPodsPerNode is the number of Kubernetes devices
                       that the Onload Device Plugin should register with the kubelet.
                       Notionally this is equivalent to the number of pods that can
-                      request an onload resource on each node.
+                      request an Onload resource on each node.
                     type: integer
                   mountOnload:
                     default: false
@@ -90,7 +92,7 @@ spec:
                 - message: SetPreload and MountOnload mutually exclusive
                   rule: '!(self.setPreload && self.mountOnload)'
               onload:
-                description: Onload is the specification of the version of onload
+                description: Onload is the specification of the version of Onload
                   to be used by this CR
                 properties:
                   imagePullPolicy:
@@ -109,7 +111,7 @@ spec:
                             building the images that contain the module. The build
                             process creates a new image which will be written to the
                             location specified by the `KernelModuleImage` parameter.
-                            If empty no builds will take place.
+                            If empty, no builds will take place.
                           properties:
                             buildArgs:
                               description: BuildArgs is an array of build variables
@@ -142,16 +144,18 @@ spec:
                           type: object
                         kernelModuleImage:
                           description: KernelModuleImage is the image that contains
-                            the out-of-tree kernel modules used by Onload.
+                            the out-of-tree kernel modules used by Onload. Absent
+                            image tags may be built by KMM.
                           type: string
                         regexp:
                           description: Regexp is a regular expression that is used
                             to match against the kernel versions of the nodes in the
-                            cluster
+                            cluster. Use also in place of literal strings.
                           type: string
                         sfc:
                           description: SFC optionally specifies that the controller
-                            will manage the SFC kernel module.
+                            will manage the SFC kernel module. Incompatible with boot-time
+                            loading approaches.
                           type: object
                       required:
                       - kernelModuleImage
@@ -160,10 +164,10 @@ spec:
                     type: array
                   userImage:
                     description: UserImage is the image that contains the built userland
-                      objects, used by the cplane and deviceplugin DaemonSets.
+                      objects, used within the Onload Device Plugin DaemonSet.
                     type: string
                   version:
-                    description: Version string to associate with this onload CR.
+                    description: Version string to associate with this Onload CR.
                     type: string
                 required:
                 - kernelMappings
@@ -173,12 +177,12 @@ spec:
               selector:
                 additionalProperties:
                   type: string
-                description: Selector defines the set of nodes that this onload CR
+                description: Selector defines the set of nodes that this Onload CR
                   will run on.
                 type: object
               serviceAccountName:
                 description: ServiceAccountName is the name of the service account
-                  that the objects created by the onload operator will use.
+                  that the objects created by the Onload Operator will use.
                 type: string
             required:
             - devicePlugin
@@ -187,8 +191,8 @@ spec:
             - serviceAccountName
             type: object
           status:
-            description: Status contains the statuses for onload and related products
-              that are controlled by the onload operator
+            description: Status contains the statuses for Onload and related products
+              that are controlled by the Onload Operator
             properties:
               conditions:
                 description: Conditions store the status conditions of Onload
@@ -260,10 +264,10 @@ spec:
                   type: object
                 type: array
               devicePlugin:
-                description: Status of the device plugin
+                description: Status of Onload Device Plugin
                 type: object
               onload:
-                description: Status of onload components
+                description: Status of Onload components
                 type: object
             required:
             - devicePlugin

--- a/config/manifests/bases/onload-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/onload-operator.clusterserviceversion.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:

--- a/config/samples/onload/base/onload_v1alpha1_onload.yaml
+++ b/config/samples/onload/base/onload_v1alpha1_onload.yaml
@@ -37,27 +37,86 @@ subjects:
 - kind: ServiceAccount
   name: onload-operator-sa
 ---
+# Property descriptions for the Onload CRD version running in your cluster
+# is available via the command `kubectl explain onload.spec`.
 apiVersion: onload.amd.com/v1alpha1
 kind: Onload
+
+# Standard object's metadata.
 metadata:
   name: onload
+
+# Spec is the top-level specification for Onload and related products that
+# are controlled by the Onload Operator. Required.
 spec:
+
+  # ServiceAccountName is the name of the service account that the objects
+  # created by the Onload Operator will use. Required.
   serviceAccountName: onload-operator-sa
+
+  # Selector defines the set of nodes that this Onload CR will run on. Required.
   selector:
+
+    # Example node label
     node-role.kubernetes.io/worker: ""
+
+  # Onload is the specification of the version of Onload to be used by this CR.
+  # Required.
   onload:
+
+    # KernelMappings is a list of pairs of kernel versions and container images.
+    # This allows for flexibility when there are heterogenous kernel versions on
+    # the nodes in the cluster. Required. For descriptions of contents,
+    # see ../overlays/in-cluster-build-ocp/patch-onload.yaml
     kernelMappings: []
+
+    # UserImage is the image that contains the built userland objects, used
+    # within the Onload Device Plugin DaemonSet. Required.
     userImage: onload/onload-user
-    version:
+
+    # Version string to associate with this Onload CR. Required.
+    version: # eg. 8.0.0.0
+
+    # ImagePullPolicy is the policy used when pulling images. Optional.
     imagePullPolicy: Always
+
+  # DevicePlugin is further specification for the Onload Device Plugin which
+  # uses the device plugin framework to provide an `amd.com/onload` resource.
+  # Image location is not configured here; see Onload Operator deployment.
+  # Required.
   devicePlugin:
+
+    # ImagePullPolicy is the policy used when pulling images. Optional.
     imagePullPolicy: Always
-    # Limit number of pods that can request Onload on a node
+
+    # MaxPodsPerNode is the number of Kubernetes devices that the Onload Device
+    # Plugin should register with the kubelet. Notionally this is equivalent to
+    # the number of pods that can request an Onload resource on each node.
+    # Optional.
     #maxPodsPerNode: 100
-    # Uncomment to select whether LD_PRELOAD should be set by the device plugin
-    # preload: true
-    # mountOnload: false
-    # hostOnloadPath: /opt/onload
-    # baseMountPath: /opt/onload
-    # binMountPath: /usr/bin
-    # libMountPath: /usr/lib64
+
+    # Preload determines whether the Onload Device Plugin will set LD_PRELOAD
+    # for pods using Onload. Mutually exclusive with MountOnload. Optional.
+    #preload: true
+
+    # MountOnload is used by the Onload Device Plugin to decide whether to mount
+    # the `onload` script as a file in the container's filesystem. `onload` is
+    # mounted at `<baseMountPath>/<binMountpath>` Mutually exclusive with
+    # Preload. Optional.
+    #mountOnload: false
+
+    # HostOnloadPath is the base location of Onload files on the host
+    # filesystem. Optional.
+    #hostOnloadPath: /opt/onload
+
+    # BaseMountPath is a prefix to be applied to all Onload file mounts in the
+    # container's filesystem. Optional.
+    #baseMountPath: /opt/onload
+
+    # BinMountPath is the location to mount Onload binaries in the container's
+    # filesystem. Optional.
+    #binMountPath: /usr/bin
+
+    # LibMountPath is the location to mount Onload libraries in the container's
+    # filesystem. Optional.
+    #libMountPath: /usr/lib64

--- a/config/samples/onload/overlays/in-cluster-build-ocp/patch-onload.yaml
+++ b/config/samples/onload/overlays/in-cluster-build-ocp/patch-onload.yaml
@@ -5,19 +5,54 @@ kind: Onload
 metadata:
   name: onload
 spec:
+  # For descriptions of top-level properties,
+  # see ../base/onload_v1alpha1_onload.yaml
   onload:
     version: 8.1.2.26
+
+    # Property descriptions for the version running in your cluster is available
+    # via the command `kubectl explain onload.spec.onload.kernelMappings`.
+
+    # A subset of KMM properties.
+    # Refer to KMM documentation for KernelModuleImage, Regexp, and BuildArgs.
     kernelMappings:
+
+        # Regexp is a regular expression that is used to match against the
+        # kernel versions of the nodes in the cluster.
+        # Use also in place of literal strings. Required.
       - regexp: '^.*\.x86_64$'
+
+        # KernelModuleImage is the image that contains the out-of-tree kernel
+        # modules used by Onload. Absent image tags may be built by KMM.
+        # Required.
         kernelModuleImage: onload/onload-module
+
+        # Build specifies the parameters that are to be passed to the Kernel
+        # Module Management operator when building the images that contain the
+        # module. The build process creates a new image which will be written to
+        # the location specified by the `KernelModuleImage` parameter. If empty,
+        # no builds will take place. Optional.
         build:
+
+          # BuildArgs is an array of build variables that are provided to the
+          # image building backend.
+          # Optional. When used, both `name` & `value` are required.
+          buildArgs:
+
+            # Example Dockerfile ARG.
+            # String appended to `onload_build` script command. Optional.
+            - name: ONLOAD_BUILD_PARAMS
+              value: ""
+
+            # Example Dockerfile ARG.
+            # Location of `onload-source` container image. Required.
+            - name: ONLOAD_SOURCE
+              value: onload/onload-source
+
+          # ConfigMap that holds Dockerfile contents. Required.
           dockerfileConfigMap:
             name: onload-module-dockerfile
-          buildArgs:
-          - name: ONLOAD_BUILD_PARAMS
-            value: ""
-          - name: ONLOAD_SOURCE
-            value: onload/onload-source
-        # Deploy `sfc` Module CR in addition to `onload` Module CR.
-        # (Incompatible with MachineConfig approach.)
-        #sfc: {}
+
+        # SFC optionally specifies that the controller will manage the SFC
+        # kernel. Incompatible with boot-time loading approaches. Optional.
+        sfc: {}

--- a/config/samples/onload/overlays/pre-built/patch-onload.yaml
+++ b/config/samples/onload/overlays/pre-built/patch-onload.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   onload:
     kernelMappings:
+      # Literal strings example provided here as a method of self-documenting which images have been pre-built.
+      # The regular expression & `${KERNEL_FULL_VERSION}` variable method is also supported with pre-built images.
       - regexp: 4.18.0-372.49.1.el8_6.x86_64
         kernelModuleImage: image-registry.openshift-image-registry.svc:5000/onload-clusterlocal/onload-module:8.1.2.26-4.18.0-372.49.1.el8_6.x86_64
 


### PR DESCRIPTION
Clarified some `onload_types.go` comments and regenerated bundle. Manually updated sample inline; no further changes expected until beyond v1alpha1, so scripted generation seems excessive for now.

Changed sfc to be enabled by default in recommended off-the-shelf example, as discussed.