### PR TITLE
ON-15464: Recommended Labels and onload-version rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ device-plugin-docker-build: test ## Build docker image with the manager.
 	docker build -t ${DEVICE_IMG} -f deviceplugin.Dockerfile --network="host" .
 
 .PHONY: device-plugin-docker-push
-device-plugin-docker-push: test ## Push docker image to the registry.
+device-plugin-docker-push: ## Push docker image to the registry.
 	docker push ${DEVICE_IMG}
 
 .PHONY: sfc-mc-docker-build

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -11,8 +11,8 @@ namespace: onload-operator-system
 namePrefix: onload-operator-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app.kubernetes.io/part-of: onload
 
 resources:
 - ../crd

--- a/config/samples/onload/base/kustomization.yaml
+++ b/config/samples/onload/base/kustomization.yaml
@@ -5,5 +5,8 @@ resources:
 - onload_v1alpha1_onload.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples
 
+commonLabels:
+  app.kubernetes.io/part-of: onload
+
 configurations:
 - configurations.yaml

--- a/scripts/machineconfig/99-sfc-machineconfig.bu
+++ b/scripts/machineconfig/99-sfc-machineconfig.bu
@@ -7,6 +7,7 @@ metadata:
   name: 99-sfc-machineconfig
   labels:
     machineconfiguration.openshift.io/role: SED_NODE_TYPE
+    app.kubernetes.io/part-of: onload
 systemd:
   units:
     - name: sfc-replace-kernel-module.service

--- a/scripts/profiles/profile_to_configmap.sh
+++ b/scripts/profiles/profile_to_configmap.sh
@@ -123,6 +123,8 @@ for profile in $profiles; do
   echo "kind: ConfigMap"
   echo "metadata:"
   echo "  name: onload-$(basename "$profile" .opf)-profile"
+  echo "  labels:"
+  echo "    app.kubernetes.io/part-of: onload"
   echo "data:"
   onload_import "$profile" "$@"
   echo "---"


### PR DESCRIPTION
For upcoming troubleshooting guide.

* Namespaced the `onload-version` label. Not required here but now sticks out when compared alongside other identifiers. Clarifies that it's not for general users to touch arbitrarily. Candidate for adding to upgrade docs.
* Added `/part-of` and `/managed-by` [Recommended Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) for much easier selection in troubleshooting guide, eliminating hacky/greedy grepping or awkward 'field selectors'. Also added `/component` and `/instance` for clarity.
* Renamed `onload-onload-device-plugin-init` to just `init` as name need only be unique within pod
* Removed redundant test target from `make device-plugin-docker-push`

The `onload.amd.com/name` label is unchanged, only a DRY tweak.

Would have liked to add `/version` too but there are many different product versions and some would require extra user changes, risking staleness.