### PR TITLE
cleanup: Static Analysis workflow -- split Go & non-Go

### DIFF
--- a/.github/workflows/static-go.yml
+++ b/.github/workflows/static-go.yml
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: MIT
+# (c) Copyright 2023-2024 Advanced Micro Devices, Inc.
+name: "Static Analysis - Go"
+
+on:
+  workflow_dispatch:
+    inputs:
+      lint_codebase:
+        description: Lint all files instead of changed
+        default: false
+        required: true
+        type: boolean
+  pull_request:
+    branches: [master]
+    paths:
+      - '**.go'
+      - go.mod
+      - Makefile
+  push:
+    branches: [master]
+    paths:
+      - '**.go'
+      - go.mod
+      - Makefile
+#  schedule:
+#    - cron: '44 2 * * 5'
+
+env:
+  lint-all: ${{ github.event_name == 'workflow_dispatch' && inputs.lint_codebase }}
+permissions:
+  contents: read
+jobs:
+  # super-linter has issues with go-1.21 & linting of changed go files only
+  lint-go:
+    name: Go Linter
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Go - setup env
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+        cache: false # handled by linter action
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.54 # go 1.21
+        only-new-issues: ${{ !env.lint-all }}
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Go - setup env
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+
+    - run: make test
+
+  analyse:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    needs: [ unit-tests, lint-go ] # cost mitigation
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ go ]
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Go - setup env
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+
+    - name: Go - download dependencies
+      run: go get
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-extended,security-and-quality
+
+    - name: Go Build on Operator, Device Plugin, and Worker
+      run: make build device-plugin-build worker-build
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# (c) Copyright 2023 Advanced Micro Devices, Inc.
+# (c) Copyright 2023-2024 Advanced Micro Devices, Inc.
 name: "Static Analysis"
 
 on:
@@ -12,15 +12,17 @@ on:
         type: boolean
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**.go'
+      - go.mod
   push:
     branches: [master]
-#  schedule:
-#    - cron: '44 2 * * 5'
+    paths-ignore:
+      - '**.go'
+      - go.mod
 
 env:
   lint-all: ${{ github.event_name == 'workflow_dispatch' && inputs.lint_codebase }}
-permissions:
-  contents: read
 jobs:
   lint-general:
     name: Super Linter
@@ -28,6 +30,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      packages: read
       statuses: write
     steps:
 
@@ -37,7 +40,7 @@ jobs:
         fetch-depth: 0 # super-linter req
 
     - name: Super Linter
-      uses: docker://ghcr.io/super-linter/super-linter:slim-v5.3.1 # go-1.21
+      uses: super-linter/super-linter/slim@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # super-linter is designed around linting changed files only,
@@ -50,82 +53,3 @@ jobs:
         ERROR_ON_MISSING_EXEC_BIT: true
         LINTER_RULES_PATH: /
         YAML_CONFIG_FILE: .yamllint.yml
-        GO_LINTER_RULES: .golangci.yml
-
-  # super-linter has issues with go-1.21 & linting of changed go files only
-  lint-go:
-    name: Go Linter
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Go - setup env
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: go.mod
-        cache: false # handled by linter action
-
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
-      with:
-        version: v1.54 # go 1.21
-        only-new-issues: ${{ !env.lint-all }}
-
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Go - setup env
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: go.mod
-
-    - run: make test
-
-  analyse:
-    name: CodeQL
-    runs-on: ubuntu-latest
-    needs: [ unit-tests, lint-go ] # cost mitigation
-    timeout-minutes: 360
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ go ]
-    steps:
-
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Go - setup env
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: go.mod
-
-    - name: Go - download dependencies
-      run: go get
-
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        queries: security-extended,security-and-quality
-
-    - name: Go Build on Operator, Device Plugin, and Worker
-      run: make build device-plugin-build worker-build
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
-


### PR DESCRIPTION
Cost/speed efficiency saving. Also standardised Super Linter config (should fix its annotation issue).